### PR TITLE
issue 40: clean up collection fixtures

### DIFF
--- a/welkin/apps/root_pageobject.py
+++ b/welkin/apps/root_pageobject.py
@@ -452,7 +452,7 @@ class RootPageObject(object):
             logger.info(f"Writing special logs.")
 
             # write the raw performance logs to /network
-            utils_file.write_traffic_log_to_file(log=performance_logs,
+            utils_file.write_network_log_to_file(log=performance_logs,
                                                  url=self.url, fname=clean_name)
 
             # write the scan logs to /console

--- a/welkin/data/users.py
+++ b/welkin/data/users.py
@@ -46,24 +46,6 @@ app_user_map = {
 }
 
 
-def get_users_for_tier(tier, app=None, verbose=False):
-    """
-         Extract the test users for the specified tier and specified app.
-
-         Note; can we deprecate this since we use AWS?
-
-         :param tier: str, one of 'int', 'stage', 'prod'
-         :param app: str, defaults to None
-         :param verbose: bool, whether to log additional information
-         :return: dict of users
-     """
-    logger.info(f"Getting tier '{tier}' users for '{app if app else 'all apps'}'")
-    these_users = app_user_map[tier][app]
-    if verbose:
-        logger.info('\nFound users:\n%s' % utils.plog(these_users))
-    return these_users
-
-
 def get_specific_user(tier, app, fuid, verbose=False):
     """
         Return a single user `fuid` for tier + app.

--- a/welkin/framework/utils.py
+++ b/welkin/framework/utils.py
@@ -9,7 +9,7 @@ import pytest
 logger = logging.getLogger(__name__)
 
 
-def create_testrun_folder(timestamped_name):
+def create_test_output_folder(timestamped_name):
     """
         Every pytest invocation triggers a bunch of logging actions. During
         the pytest start up routines, logging is enabled and configured,
@@ -45,7 +45,7 @@ def create_testrun_folder(timestamped_name):
     return welkin_root_path, testrun_path
 
 
-def create_testrun_subfolder(path, folder):
+def create_test_output_subfolder(path, folder):
     """
         Create a folder `folder` at path `path`.
 

--- a/welkin/framework/utils_file.py
+++ b/welkin/framework/utils_file.py
@@ -26,9 +26,9 @@ def write_cookies_to_file(cookies, url, fname=''):
     logger.info(f"\nSaved cookies: {path}.")
 
 
-def write_traffic_log_to_file(log, url, fname=''):
+def write_network_log_to_file(log, url, fname=''):
     """
-        Save the browser network traffic log as json to a file.
+        Save the browser network log as json to a file.
 
         :param log:
         :param url: str, url for the current page
@@ -39,14 +39,14 @@ def write_traffic_log_to_file(log, url, fname=''):
     # note: json files don't allow comments, so we'd not be able
     # to write the url to the file
     filename = f"/{time.strftime('%H%M%S')}_{utils.path_proof_name(fname)}.json"
-    path = pytest.welkin_namespace['testrun_traffic_log_folder'] + filename
+    path = pytest.welkin_namespace['testrun_network_log_folder'] + filename
 
     wrapper = {}
     wrapper['_page'] = url
     wrapper['chrome network logs'] = log
     with open(path, 'a') as f:
         f.write(utils.plog(wrapper))
-    logger.info(f"\nSaved traffic log: {path}.")
+    logger.info(f"\nSaved browser network log: {path}.")
 
 
 def write_console_log_to_file(log, url, fname=''):

--- a/welkin/tests/examples/test_api_colors.py
+++ b/welkin/tests/examples/test_api_colors.py
@@ -19,7 +19,7 @@ class ExampleColourLoversTests(object):
     color_endpoint = color.ColorEndpoint()
     colors_endpoint = colors.ColorsEndpoint()
 
-    def test_get_color(self):
+    def test_get_color(self, colourlovers):
         """
             Simple test for the "color" endpoint, using hardcoded data.
 
@@ -40,7 +40,7 @@ class ExampleColourLoversTests(object):
         # test point: verify that the json keys are correct
         assert self.color_endpoint.verify_keys_in_response(res.json()[0].keys())
 
-    def test_get_colors(self):
+    def test_get_colors(self, colourlovers):
         """
             Simple test for the "colors" endpoint, using no data. This just looks at the structure
             of the returned json.
@@ -58,7 +58,7 @@ class ExampleColourLoversTests(object):
         assert self.color_endpoint.verify_keys_in_response(res.json()[0].keys())
 
     @pytest.mark.parametrize('colors_data', color_data, ids=[c[1] for c in color_data])
-    def test_colordata(self, colors_data):
+    def test_colordata(self, colourlovers, colors_data):
         """
             This is a parametrized test case using a data source consisting of a list of lists.
             Pytest will iterate over the data model and call this test method once for each top

--- a/welkin/tests/examples/test_api_genderize.py
+++ b/welkin/tests/examples/test_api_genderize.py
@@ -21,7 +21,7 @@ class ExampleGenderizerTests(object):
     @pytest.mark.parametrize('good_name',
                              [n for n in good_names_single],
                              ids=[n[0] for n in good_names_single])
-    def test_get_single_name(self, good_name):
+    def test_get_single_name(self, genderizer, good_name):
         """
             For the supplied name and expected gender, verify that the API response
             contains the name and expected gender.
@@ -56,7 +56,7 @@ class ExampleGenderizerTests(object):
 
     @pytest.mark.parametrize('multiple_good_names', [n for n in good_names_multiple],
                              ids=['+'.join(l[0]) for l in good_names_multiple])
-    def test_get_multiple_good_names(self, multiple_good_names):
+    def test_get_multiple_good_names(self, genderizer, multiple_good_names):
         """
             For the supplied list of names and expected genders, verify that
             the API response contains the names and expected genders.
@@ -102,7 +102,7 @@ class ExampleGenderizerTests(object):
             assert item[1] == expected[i][1], 'expected "%s", but got "%s"' % (expected[i][1], item[1])
 
     @pytest.mark.parametrize('bad_name', [n for n in bad_names_single])
-    def test_gender_not_resolved(self, bad_name):
+    def test_gender_not_resolved(self, genderizer, bad_name):
         """
             For the supplied problematic name, verify that the API response
             contains the name and null gender.
@@ -130,7 +130,7 @@ class ExampleGenderizerTests(object):
 
     @pytest.mark.parametrize('multiple_bad_names', [n for n in bad_names_multiple],
                              ids=['+'.join(l[0]) for l in bad_names_multiple])
-    def test_get_multiple_bad_names(self, multiple_bad_names):
+    def test_get_multiple_bad_names(self, genderizer, multiple_bad_names):
         """
             For the supplied list of names and expected genders, verify that
             the API response contains the names and expected genders.
@@ -171,7 +171,7 @@ class ExampleGenderizerTests(object):
             # test point: verify the expected gender for the name
             assert item[1] == expected[i][1], 'expected "%s", but got "%s"' % (expected[i][1], item[1])
 
-    def test_int_as_name(self):
+    def test_int_as_name(self, genderizer):
         """
             Integers are converted to strings by the API.
         """
@@ -192,7 +192,7 @@ class ExampleGenderizerTests(object):
 
     @pytest.mark.parametrize('more_than_11_names', [n for n in too_many_names],
                              ids=['+'.join(l[0]) for l in too_many_names])
-    def test_exceed_multiple_request_limit(self, more_than_11_names):
+    def test_exceed_multiple_request_limit(self, genderizer, more_than_11_names):
         """
             Request 11 names in one API call; the limit is 10 so any name after the tenth gets ignored.
 

--- a/welkin/tests/examples/test_dadjokes.py
+++ b/welkin/tests/examples/test_dadjokes.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 @pytest.mark.api
 class DadJokesTests(object):
 
-    def test_search_for_joke(self):
+    def test_search_for_joke(self, dadjokes):
         terms = 'bicycle'
         api = SearchEndpoint()
         res = api.search_for_joke(terms, verbose=True)

--- a/welkin/tests/examples/test_duckduckgo.py
+++ b/welkin/tests/examples/test_duckduckgo.py
@@ -207,7 +207,7 @@ class ExampleDuckduckgoTests(object):
         assert len(relevant_results) > 5, \
             f"Only {len(relevant_results)} relevant results found, hoped for 5"
 
-    def test_duckduckgo_router(self, driver):
+    def test_duckduckgo_router(self, driver, duckduckgo):
         """
             Using a correctly-spelled query string, validate some results data
             test points on the search results page.


### PR DESCRIPTION
data/users.py
+ deleted get_users_for_tier()

framework/utils_files.py
+ renamed create_testrun_folder() to create_test_output_folder()
+ renamed create_testrun_subfolder() top create_test_output_subfolder()
+ renamed write_traffic_log_to_file() to write_network_log_to_file(), and updated it to use the namepace key 'testrun_network_log_folder' instead of 'testrun_traffic_log_folder'

apps/root_pageobject.py
+ updated save_browser_logs() to call write_network_log_to_file() instead of write_traffic_log_to_file()

tests/conftest.py
+ added COUNT to work around the fact that we don't have an iterable of tests to number against; instead we get one at a time
+ refactored the folder-creation logic out of pytest_collection_finish()
+ extensively refactored pytest_runtest_setup()
+ deleted set_up_apps()
+ refactored set_up_testcase_reporting()
+ deleted apps info references from set_up_tier_globals()
+ added app fixtures colourlovers, dadjokes, genderizer for example apps
+ added colourlovers, dadjokes, genderizer to the apis list in set_up_testcase_reporting()
+ fixed the fixture scope set up for auth()
+ deleted the fixture scope set up for browser()

tests/examples/test_duckduckgo.py
+ added duckduckgo fixture arg to test_duckduckgo_router()

tests/examples/test_api_colors.py
+ added argument colourlovers to test methods

tests/examples/test_api_genderize.py
+ added argument genderizer to test methods

tests/examples/test_api_dadjokes.py
+ added argument dadjokes to test methods