### PR TITLE
issue 44: support secure strings from AWS PS

### DIFF
--- a/welkin/apps/README_pageobject_model.md
+++ b/welkin/apps/README_pageobject_model.md
@@ -7,6 +7,7 @@
   + [Page Object instantiation managed through the router pattern](#page-object-instantiation-managed-through-the-router-pattern)
 + [Separating the authenticated and non-authenticated experience](#separating-the-authenticated-and-non-authenticated-experience )
 + [Browser Interaction Event Wrapping](#browser-interaction-event-wrapping)
++ [Adding Framework Support for New Applications](#adding-framework-support-for-new-applications)
 
 
 ## Application Wrappers
@@ -59,7 +60,17 @@ This layout requires the **routings.py** file to have different mapping dicts fo
 + viewing a noauth page like the login form, and successfully logging in
 + viewing an authenticated page, and successfully logging out
 
+
 ## Browser Interaction Event Wrapping
-With modern web apps created with UI frameworks that use Javascript to manipulate the page DOM, it's challenging to programmatically interact with pages that respond and change based on interactiom triggers. For example, clicking in a form field can trigger an app state change; _apps that live-validate a form field's text input as the user types it in_ are common.  
+With modern web apps created with UI frameworks that use Javascript to manipulate the page DOM, it's challenging to programmatically interact with pages that respond and change based on interaction triggers. For example, clicking in a form field can trigger an app state change; _apps that live-validate a form field's text input as the user types it in_ are common.  
 
 Welkin identifies interaction actions and triggers and wraps the direct webdriver interaction mechanisms with local methods that log "events". These events provide hooks for deeper app state inspection, allowing for better testing of error states and internal app properties.  
+
+
+## Adding Framework Support for New Applications
+When you want to add support for a new application to test, you need to make the following changes:
+1. add the wrapper as described above
+2. add the appropriate app data to `app_tier_map` in data/applications.py
+3. add a fixture with the name of the app to tests/conftest.py. Set to a scope of "session".
+4. add the string name of the fixture to the `set_up_testcase_reporting` in tests/conftest.py, to either the `web_apps` or the `apis` list. This controls the creation of logging output folders for kinds of data that depend on the category of app.  
+5. after you create any test user accounts data, you need to add paths to the AWS Parameter Store; see integrations/aws/README_aws.md. 

--- a/welkin/data/users.py
+++ b/welkin/data/users.py
@@ -17,30 +17,30 @@ in the AWS ParameterStore. See integrations/aws/README_aws.md.
 """
 app_user_map = {
     'int': {
-        'duckduckgo': {
+        'dummy_app': {
             'user01': {
-                'app': 'duckduckgo',
+                'app': 'dummy_app',
                 'email': 'int_user@example.com',
                 'fuid': 'user01'
             }
         }
     },
     'stage': {
-        'duckduckgo': {
+        'dummy_app': {
             'user01': {
-                'app': 'duckduckgo',
+                'app': 'dummy_app',
                 'email': 'test_user@example.com',
                 'fuid': 'user01'
             }
         }
     },
     'prod': {
-        'duckduckgo': {
+        'dummy_app': {
             'user01': {
-                'app': 'duckduckgo',
+                'app': 'dummy_app',
                 'email': 'prod_user@example.com',
                 'fuid': 'user01'
-            }
+            },
         }
     }
 }

--- a/welkin/framework/utils_file.py
+++ b/welkin/framework/utils_file.py
@@ -227,3 +227,23 @@ def write_request_to_file(response, url, fname=''):
         f.write(f"\n\n{'~' * 45}\n\n")
 
     logger.info(f"Saved headers: {path}")
+
+
+def write_sdk_response_to_file(response, sdk_app, fname=''):
+    """
+        Save the response from an SDK. Unlike typical API calls, the
+        SDK calls don't necessarily have the standard http request data
+        patterns.
+
+        These SDKs will be wrappers in the welkin/integrations folder.
+
+        :param response: SDK response, probably json or a dict
+        :param sdk_app: str name of the SDK
+        :param fname: str, first part of filename, will be appended with
+                           timestamp; defaults to empty string
+        :return: None
+    """
+    filename = f"/{time.strftime('%H%M%S')}_{utils.path_proof_name(fname)}.json"
+    path = pytest.welkin_namespace['testrun_integrations_log_folder'] + filename
+    with open(path, 'a') as f:
+        f.write(utils.plog(response))

--- a/welkin/integrations/aws/README_aws.md
+++ b/welkin/integrations/aws/README_aws.md
@@ -107,6 +107,8 @@ This yields a string path "tier/application/username". We will use this as the n
 1. go to ```AWS --> Systems Manager --> Parameter Store```
 2. create a parameter with a name that reflects the unique prepend + node path, for example "/welkin/prod/duckduckgo/user01"; that leading slash is required.
 3. specific an appropriate value type
-4. assign a tag that references the framework, for exmaple "ok_welkin"
+4. assign a tag that references the framework, for example "ok_welkin"
 
 You will have to repeat this for *every* password (parameter) you need to support.
+
+Note: it may take a few minutes for the new parameters to get associated with the user. Until that happens, you may get a ```botocore.exceptions.ClientError```.

--- a/welkin/integrations/aws/aws.py
+++ b/welkin/integrations/aws/aws.py
@@ -2,6 +2,7 @@ import logging
 import boto3
 
 from welkin.framework import utils
+from welkin.framework import utils_file
 
 logger = logging.getLogger(__name__)
 
@@ -23,7 +24,8 @@ class AWSSession:
         self.session = boto3.Session(region_name=region)
         self.region = region
         if verbose:
-            logger.info(f"\nAWS session created for '{self.region}': {self.session} ({id(self.session)})")
+            logger.info(f"\nAWS session created for '{self.region}': "
+                        f"{self.session} ({id(self.session)})")
 
 
 class AWSClient:
@@ -40,6 +42,7 @@ class AWSClient:
             :param session: boto3 session object
             :param resource_name: str, service/resource identifier
         """
+        self.name = 'AWS client'
         # extract the boto3 object from the Welkin object
         self.session = session.session
         self.region = session.region
@@ -48,16 +51,18 @@ class AWSClient:
         client = self.session.client(resource_name)
         self.client = client
 
-    def get_password(self, aws_key_name, decrypt=False):
+    def get_parameter_data(self, aws_key_name, decrypt=False):
         """
-            Get the value for key `aws_key_name` from the AWS
-            Parameter store.
+            Get the value (and all the associated meta data) for key
+            `aws_key_name` from the AWS Parameter store.
 
-            This is really for any parameter in the AWS Parameter Store,
-            but for disambiguation we call this a password operation.
+            If this used for a password, set the parameter value in AWS
+            as a Secure String. This will encrypt the value using the
+            AWS KMS service, so if you are getting a encrypted password,
+            pass the `decrypt=True` argument.
 
             See the README for more context as well as AWS set up
-            information to support passwords (parameters).
+            information to support passwords as parameters.
 
             :param aws_key_name: str, key name (looks likes a path)
             :param decrypt: bool, True or False; defaults to False
@@ -65,4 +70,9 @@ class AWSClient:
         """
         res = self.client.get_parameter(Name=aws_key_name,
                                         WithDecryption=decrypt)
+        # write the response headers to a file
+        utils_file.write_sdk_response_to_file(
+            utils.strip_password_for_reporting(res),
+            sdk_app=self.name,
+            fname='get param')
         return res

--- a/welkin/models/user.py
+++ b/welkin/models/user.py
@@ -82,11 +82,12 @@ class ApplicationUser():
         param_key = f"/welkin/{self.tier}/{self.application}/{self.fuid}"
         return param_key
 
-    def get_password_from_aws(self, aws_session, verbose=False):
+    def get_password_from_aws(self, aws_session, decrypt=False, verbose=False):
         """
             Make an AWS call to retrieve the password for this user.
 
             :param aws_session: AWS session object
+            :param decrypt: bool, True to decrypt the AWS param value
             :param verbose: bool, True to output additional information
             :return: None
         """
@@ -94,10 +95,11 @@ class ApplicationUser():
         client = AWSClient(aws_session, resource_name=resource)
 
         # make the AWS get parameter call
-        res = client.get_password(aws_key_name=self.password_key,
-                                  decrypt=False)
+        res = client.get_parameter_data(aws_key_name=self.password_key,
+                                        decrypt=decrypt)
         if verbose:
-            msg1 = f"AWS response:\n{utils.plog(res)}"
+            logging_data = utils.plog(utils.strip_password_for_reporting(res))
+            msg1 = f"AWS response:\n{logging_data}"
             msg2 = f"\n\n\n{'#-' * 50}\nNOTE: Don't log passwords!" \
                    f"\n{msg1}\n{'#-' * 50}\n\n\n"
             logger.info(msg2)

--- a/welkin/tests/integrations/test_aws_integration.py
+++ b/welkin/tests/integrations/test_aws_integration.py
@@ -17,10 +17,10 @@ class AwsIntegrationTests(object):
         """
         aws_region = 'us-west-1'
         tier = TIER
-        appname = 'duckduckgo'
+        appname = 'dummy_app'
         user = 'user01'
         param_key = f"/welkin/{tier}/{appname}/{user}"
-        expected_param_value = f"password for user \"{param_key}\""
+        expected_param_value = f"secure password for user \"{param_key}\""
 
         # create a session object tied to the local default config
         # for region and IAM user
@@ -30,8 +30,9 @@ class AwsIntegrationTests(object):
         client = AWSClient(session, resource_name='ssm')
 
         # make the AWS get parameter call
-        res = client.get_password(aws_key_name=param_key, decrypt=False)
-        logger.info(f"\nAWS response:\n{utils.plog(res)}")
+        res = client.get_parameter_data(aws_key_name=param_key, decrypt=True)
+        logger.info(f"\nAWS response:\n"
+                    f"{utils.plog(utils.strip_password_for_reporting(res))}")
 
         # check the expected parameter (aka the "password")
         actual_param_value = res['Parameter']['Value']
@@ -42,10 +43,10 @@ class AwsIntegrationTests(object):
             Validation for the AWS integration code with default args.
         """
         tier = TIER
-        appname = 'duckduckgo'
+        appname = 'dummy_app'
         user = 'user01'
         param_key = f"/welkin/{tier}/{appname}/{user}"
-        expected_param_value = f"password for user \"{param_key}\""
+        expected_param_value = f"secure password for user \"{param_key}\""
 
         # create a session object tied to the local default config
         # for region and IAM user
@@ -55,8 +56,9 @@ class AwsIntegrationTests(object):
         client = AWSClient(session, resource_name='ssm')
 
         # make the AWS get parameter call
-        res = client.get_password(aws_key_name=param_key, decrypt=False)
-        logger.info(f"\nAWS response:\n{utils.plog(res)}")
+        res = client.get_parameter_data(aws_key_name=param_key, decrypt=True)
+        logger.info(f"\nAWS response:\n"
+                    f"{utils.plog(utils.strip_password_for_reporting(res))}")
 
         # check the expected parameter (aka the "password")
         actual_param_value = res['Parameter']['Value']
@@ -72,18 +74,19 @@ class AwsIntegrationTests(object):
         """
         # setup
         tier = TIER
-        appname = 'duckduckgo'
+        appname = 'dummy_app'
         user = 'user01'
         param_key = f"/welkin/{tier}/{appname}/{user}"
-        expected_param_value = f"password for user \"{param_key}\""
+        expected_param_value = f"secure password for user \"{param_key}\""
         session = auth
 
         # create a client tied to this session
         client = AWSClient(session, resource_name='ssm')
 
         # make the AWS get parameter call
-        res = client.get_password(aws_key_name=param_key, decrypt=False)
-        logger.info(f"\nAWS response:\n{utils.plog(res)}")
+        res = client.get_parameter_data(aws_key_name=param_key, decrypt=True)
+        logger.info(f"\nAWS response:\n"
+                    f"{utils.plog(utils.strip_password_for_reporting(res))}")
 
         # check the expected parameter (aka the "password")
         actual_param_value = res['Parameter']['Value']
@@ -99,18 +102,19 @@ class AwsIntegrationTests(object):
         """
         # setup
         tier = TIER
-        appname = 'duckduckgo'
+        appname = 'dummy_app'
         user = 'user01'
         param_key = f"/welkin/{tier}/{appname}/{user}"
-        expected_param_value = f"password for user \"{param_key}\""
+        expected_param_value = f"secure password for user \"{param_key}\""
         session = auth
 
         # create a client tied to this session
         client = AWSClient(session, resource_name='ssm')
 
         # make the AWS get parameter call
-        res = client.get_password(aws_key_name=param_key, decrypt=False)
-        logger.info(f"\nAWS response:\n{utils.plog(res)}")
+        res = client.get_parameter_data(aws_key_name=param_key, decrypt=True)
+        logger.info(f"\nAWS response:\n"
+                    f"{utils.plog(utils.strip_password_for_reporting(res))}")
 
         # check the expected parameter (aka the "password")
         actual_param_value = res['Parameter']['Value']
@@ -123,10 +127,10 @@ class AwsIntegrationTests(object):
         """
         # setup
         tier = TIER
-        appname = 'duckduckgo'
+        appname = 'dummy_app'
         user_id = 'user01'
         param_key = f"/welkin/{tier}/{appname}/{user_id}"
-        expected_param_value = f"password for user \"{param_key}\""
+        expected_param_value = f"secure password for user \"{param_key}\""
         session = auth
 
         # set up user object
@@ -134,7 +138,36 @@ class AwsIntegrationTests(object):
         logger.info(f"\n~~~~> user object:\n{user}")
 
         # get the password
-        user.get_password_from_aws(session, verbose=True)
+        user.get_password_from_aws(session, decrypt=True, verbose=True)
+        logger.info(f"\n~~~~> user object:\n{user}")
+
+        # check the expected parameter (aka the "password")
+        # NOTE: CAREFUL WHEN ACCESSING OR COMPARING PASSWORDS
+        actual_param_value = user.password
+        assert actual_param_value == expected_param_value
+
+    def test_integration_session_fixture_secure_user(self, auth):
+        """
+            Validation for the AWS integration code called as a fixture,
+            and using the User model.
+        """
+        # setup
+        tier = TIER
+        appname = 'dummy_app'
+        user_id = 'user01'
+        # this param_key is just used here for logging and;
+        # the key used in the AWS called is generated in the
+        # user model
+        param_key = f"/welkin/{tier}/{appname}/{user_id}"
+        expected_param_value = f"secure password for user \"{param_key}\""
+        session = auth
+
+        # set up user object
+        user = ApplicationUser(tier, appname, user_id)
+        logger.info(f"\n~~~~> user object:\n{user}")
+
+        # get the password
+        user.get_password_from_aws(session, verbose=True, decrypt=True)
         logger.info(f"\n~~~~> user object:\n{user}")
 
         # check the expected parameter (aka the "password")


### PR DESCRIPTION
apps/README_pageobject_model.md
+ added section for "Adding Framework Support for New Applications"

integrations/aws/README_aws.md
+ minor fixes

data/users.py
+ replaced "duckduckgo" users with "dummy_app"

framework/utils.py
+ added strip_password_for_reporting()

framework/utils_file.py
+ added write_sdk_response_to_file()

integrations/aws/aws.py
+ renamed get_password() to get_parameter_data()
+ added support for logging the sdk response, and stripping out the decrypted password value, in get_parameter_data()

models/user.py
+ added decrypt arg to get_password_from_aws(), and added a call to utils.strip_password_for_reporting()

tests/conftest.py
+ added aws() as not a fixture, to manage the creation of the aws session when auth() is used as a test case fixture
+ refactored auth() to call aws()
+ added support for the creation of an 'integrations' folder to set_up_testcase_reporting(), and moved 'auth' into the 'integrations' category of apps; however, always create the integrations folder

tests/integrations/test_aws_integration.py
+ added test_integration_session_fixture_secure_user()
+ updated calls on client.get_password() to client.get_parameter_data()
+ updated every test case to use the appname "dummy_app" and to use utils.strip_password_for_reporting() for any logging of the aws response