### PR TITLE
issue 49: support flake8

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
     + [Killing a Test Run](#killing-a-test-run)
     + [Command Line Arguments](#command-line-arguments)
     + [Logging](#logging)
++ [Linting with Flake8](#linting-with-flake8)
 + [Automation Examples](#automation-examples)
     + [Single-Endpoint API](#single-endpoint-api)
 + [See Also](#see-also)
@@ -163,12 +164,25 @@ HTML test results page, plus the text log of test run activity. This output is n
 cleaned up. You'll have to define a workflow for this, if you want.
 
 
-## Automation Examples
+## Linting with Flake8
+From the [**Flake8** description](https://flake8.pycqa.org/en/latest/manpage.html):
 
+"Flake8 is a command-line utility for enforcing style consistency across Python projects. By default it includes lint checks provided by the PyFlakes project, PEP-0008 inspired style checks provided by the PyCodeStyle project, and McCabe complexity checking provided by the McCabe project. It will also run third-party extensions if they are found and installed."
+
+Running flake8 against the welkin codebase:
+```
+# from the project directory
+$ flake8 > output/flake8.txt
+```
+
+Specific configuration instructions can be set in ```setup.cfg```.
+
+
+
+## Automation Examples
 Some examples of solving particular automation challenges.
 
 ### Single-Endpoint API
-
 see [Wrapper for genderizer API](welkin/apps/examples/genderize/README.md)
 
 # See Also

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ boto3 >= 1.18.45
 Cerberus >= 1.3.4
 deepdiff >= 5.5.0
 dpath >= 2.0.5
+flake8 >= 3.9.2
 pytest >= 6.2.5
 pytest-html >= 1.14.2
 pytest-instafail >= 0.3.0

--- a/welkin/apps/examples/colourlovers_api/base_endpoint.py
+++ b/welkin/apps/examples/colourlovers_api/base_endpoint.py
@@ -1,10 +1,6 @@
 import logging
-import requests
 
 from welkin.apps.root_endpoint import RootEndpoint
-from welkin.framework.exceptions import UnexpectedStatusCodeException
-from welkin.framework.exceptions import JsonPayloadException
-from welkin.framework.utils import plog
 
 
 logger = logging.getLogger(__name__)

--- a/welkin/apps/examples/colourlovers_api/color.py
+++ b/welkin/apps/examples/colourlovers_api/color.py
@@ -1,7 +1,6 @@
 import logging
 
 from welkin.apps.examples.colourlovers_api import base_endpoint
-from welkin.framework.exceptions import UnexpectedStatusCodeException
 from welkin.framework.utils import plog
 
 
@@ -44,10 +43,12 @@ class ColorEndpoint(base_endpoint.BaseEndpoint):
 
     def get_color(self, hex, format='json', expect_status=200, verbose=True, **kwargs):
         """
-            Grab the information for one color as specified by the color's hexadecimal code.
+            Grab the information for one color as specified by the
+            color's hexadecimal code.
 
-            This endpoint returns a list of json dicts, even though there is only one color returned.
-            The calling code will have to handle this list; for example:
+            This endpoint returns a list of json dicts, even though there
+            is only one color returned. The calling code will have to
+            handle this list; for example:
 
             >>> res = self.color_endpoint.get_color('000000')
             >>> assert res.json()[0]['hex'] == '000000'

--- a/welkin/apps/examples/colourlovers_api/colors.py
+++ b/welkin/apps/examples/colourlovers_api/colors.py
@@ -1,7 +1,6 @@
 import logging
 
 from welkin.apps.examples.colourlovers_api import base_endpoint
-from welkin.framework.exceptions import UnexpectedStatusCodeException
 from welkin.framework.utils import plog
 
 
@@ -44,11 +43,13 @@ class ColorsEndpoint(base_endpoint.BaseEndpoint):
 
     def get_colors(self, format='json', verbose=True, **kwargs):
         """
-            Grab the first n-results for the parameters passed to the colors endpoint.
+            Grab the first n-results for the parameters passed
+            to the colors endpoint.
 
 
-            This endpoint returns a list of json dicts, even though their is only one color returned.
-            The calling code will have to handle that. for example:
+            This endpoint returns a list of json dicts, even though there
+            is only one color returned. The calling code will have to handle
+            that. for example:
 
             >>> res = self.colors_endpoint.get_colors('000000')
             >>> assert res.json()[0]['hex'] == '000000'

--- a/welkin/apps/examples/dadjokes_api/api.py
+++ b/welkin/apps/examples/dadjokes_api/api.py
@@ -2,7 +2,6 @@ import logging
 
 from welkin.apps.root_endpoint import RootEndpoint
 from welkin.framework import utils
-from welkin.framework import utils_file
 
 logger = logging.getLogger(__name__)
 

--- a/welkin/apps/examples/data.py
+++ b/welkin/apps/examples/data.py
@@ -4,19 +4,19 @@
 """
 
 color_data = [
-    ['Light Mud'            , '#AE6B39', '174, 107, 57'],
-    ['Spearmint Green 3'    , '#23692B', '35, 105, 43'],
-    ['Peppermint Red 2'     , '#D10D3D', '209, 13, 61'],
-    ['Spearmint Green 1'    , '#B3DB7B', '179, 219, 123'],
-    ['Peppermint Red 1'     , '#D01E42', '208, 30, 66'],
-    ['Spearmint Green 2'    , '#299436', '41, 148, 54'],
-    ['Turnip'               , '#A246A2', '162, 70, 162'],
-    ['youdidn\'tneedthem'   , '#2551BB', '37, 81, 187'],
-    ['&thedreamuleftbehind' , '#14309D', '20, 48, 157'],
-    ['runningdownyourface'  , '#021C76', '2, 28, 118'],
-    ['Irememberthemakeup'   , '#DB0454', '219, 4,84'],
-    ['EE Blue'              , '#54AAB3', '84, 170, 179'],
-    ['EE Green'             , '#5E983B', '94, 152, 59'],
-    ['Deep Fuschia'         , '#841E6D', '132, 30, 109'],
-    ['Bright Blue Enamel'   , '#124CFD', '18, 76, 253'],
+    ['Light Mud'           , '#AE6B39', '174, 107, 57'],  # noqa: E203
+    ['Spearmint Green 3'   , '#23692B', '35, 105, 43'],  # noqa: E203
+    ['Peppermint Red 2'    , '#D10D3D', '209, 13, 61'],  # noqa: E203
+    ['Spearmint Green 1'   , '#B3DB7B', '179, 219, 123'],  # noqa: E203
+    ['Peppermint Red 1'    , '#D01E42', '208, 30, 66'],  # noqa: E203
+    ['Spearmint Green 2'   , '#299436', '41, 148, 54'],  # noqa: E203
+    ['Turnip'              , '#A246A2', '162, 70, 162'],  # noqa: E203
+    ['youdidn\'tneedthem'  , '#2551BB', '37, 81, 187'],  # noqa: E203
+    ['&thedreamuleftbehind', '#14309D', '20, 48, 157'],  # noqa: E203
+    ['runningdownyourface' , '#021C76', '2, 28, 118'],  # noqa: E203
+    ['Irememberthemakeup'  , '#DB0454', '219, 4,84'],  # noqa: E203
+    ['EE Blue'             , '#54AAB3', '84, 170, 179'],  # noqa: E203
+    ['EE Green'            , '#5E983B', '94, 152, 59'],  # noqa: E203
+    ['Deep Fuschia'        , '#841E6D', '132, 30, 109'],  # noqa: E203
+    ['Bright Blue Enamel'  , '#124CFD', '18, 76, 253'],  # noqa: E203
 ]

--- a/welkin/apps/examples/duckduckgo/base_page.py
+++ b/welkin/apps/examples/duckduckgo/base_page.py
@@ -1,7 +1,6 @@
 import logging
 
 from welkin.apps.root_pageobject import RootPageObject
-from welkin.framework import utils
 
 logger = logging.getLogger(__name__)
 

--- a/welkin/apps/examples/duckduckgo/noauth/pages.py
+++ b/welkin/apps/examples/duckduckgo/noauth/pages.py
@@ -1,5 +1,4 @@
 import logging
-import time
 
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import WebDriverWait
@@ -7,7 +6,6 @@ from selenium.webdriver.support import expected_conditions as EC
 from selenium.common.exceptions import TimeoutException
 
 from welkin.apps.examples.duckduckgo.noauth.base_noauth import NoAuthBasePageObject
-from welkin.framework.exceptions import PageIdentityException
 from welkin.framework import utils
 
 logger = logging.getLogger(__name__)
@@ -87,7 +85,7 @@ class HomePage(BasePage):
         self.title = f"{self.appname} — Privacy, simplified."
         if firstload:
             self.unload_checks = None
-            msg = f"Because this is the first load, do NOT check for unload!"
+            msg = "Because this is the first load, do NOT check for unload!"
             logger.warning(msg)
         else:
             # because the title is set in __init__(),

--- a/welkin/apps/examples/genderize/api.py
+++ b/welkin/apps/examples/genderize/api.py
@@ -1,8 +1,6 @@
 import logging
-import requests
 
 from welkin.apps.root_endpoint import RootEndpoint
-from welkin.framework.exceptions import UnexpectedStatusCodeException
 from welkin.framework.exceptions import JsonPayloadException
 from welkin.framework.utils import plog
 
@@ -27,7 +25,7 @@ class GenderEndpoint(RootEndpoint):
         'name': {'type': 'string'},
         'probability': {'type': 'float'}
     }
-    
+
     def __init__(self):
         """
             Initialize an endpoint object for testing.

--- a/welkin/apps/examples/genderize/genderize_data.py
+++ b/welkin/apps/examples/genderize/genderize_data.py
@@ -35,8 +35,10 @@ bad_names_multiple = [
 
 too_many_names = [
     (  # 11 names should return error
-        ('Bob', 'Joe', 'Sue', 'Spencer', 'Steve', 'John', 'Mary', 'Jane', 'Henry', 'Juan', 'Pat'),
-        ('male', 'male', 'female', 'male', 'male', 'male', 'female', 'female', 'male', 'male', 'male')
+        ('Bob', 'Joe', 'Sue', 'Spencer', 'Steve', 'John', 'Mary',
+         'Jane', 'Henry', 'Juan', 'Pat'),
+        ('male', 'male', 'female', 'male', 'male', 'male', 'female',
+         'female', 'male', 'male', 'male')
     ),
 
 ]

--- a/welkin/apps/root_endpoint.py
+++ b/welkin/apps/root_endpoint.py
@@ -1,9 +1,6 @@
 import logging
-import pytest
 import requests
-import json
 import uuid
-from collections import namedtuple
 from cerberus import Validator
 
 from welkin.framework import utils
@@ -83,7 +80,7 @@ class RootEndpoint(object):
                     params=params
                 )
             else:
-                logger.warning(f"Choosing not to use the requests session object.")
+                logger.warning("Choosing not to use the requests session object.")
                 res = requests.get(
                     url,
                     headers=self.headers,
@@ -97,7 +94,7 @@ class RootEndpoint(object):
                     headers=self.headers,
                     verify=True)
             else:
-                logger.warning(f"Choosing not to use the requests session object.")
+                logger.warning("Choosing not to use the requests session object.")
                 res = requests.get(
                     url,
                     headers=self.headers,
@@ -145,7 +142,7 @@ class RootEndpoint(object):
             logger.error('Comparison results: Keys are NOT equal.')
             logger.error(f"Expected keys:\n{utils.plog(expected)}")
             logger.error(f"Actual keys:\n{utils.plog(actual)}")
-            raise JsonPayloadException(f"Actual keys don't match expected keys.")
+            raise JsonPayloadException("Actual keys don't match expected keys.")
 
     def validate_schema(self, response_data, verbose=False):
         """

--- a/welkin/apps/root_pageobject.py
+++ b/welkin/apps/root_pageobject.py
@@ -67,7 +67,7 @@ class RootPageObject(object):
         """
         # get the previous page's name; remember that the browser has changed
         # state and we are trying to catch the page object up to the browser
-        last_page = self.name
+        last_page = self.name  # noqa: F841
 
         # unload steps, if needed
         self.verify_unload(screenshot=True, verbose=True)
@@ -241,8 +241,10 @@ class RootPageObject(object):
             [(False, By.CSS_SELECTOR, '#layoutVnsContent ul')]
 
             The available load checks are:
-                checks.expect_element_to_be_present(): Triggered by `True` as the first value in the self.load_checks
-                checks.expect_element_to_be_gone(): Triggered by `False` as the first value in the self.load_checks
+                checks.expect_element_to_be_present(): Triggered by `True`
+                    as the first value in the self.load_checks
+                checks.expect_element_to_be_gone(): Triggered by `False`
+                    as the first value in the self.load_checks
 
             :param waitfor: int, wait time page load verification, defaults to 30 seconds
             :param screenshot: bool, whether to take screenshot if check fails
@@ -273,7 +275,7 @@ class RootPageObject(object):
             if verbose:
                 logger.info(f"\n====> load check: {check} for '{self.name}'")
             # not pythonic, but also not ambiguous: 'True' means "should be present"
-            if check[0] == True:
+            if check[0] == True:  # noqa: E712
                 res = checks.expect_element_to_be_present(self, check, waitfor)
                 if res:
                     # there's problem, so add the check to our collection
@@ -287,7 +289,7 @@ class RootPageObject(object):
         # loop over the errors and set up the PageLoadException object
         if found_problems:
             # save the logs
-            logger.info(f"Writing special logs because of load errors")
+            logger.info("Writing special logs because of load errors")
             self.save_browser_logs()
             payload = {'page': f"Failed to load page '{self.name}'", 'errors': dict()}
             for validation in found_problems:
@@ -324,7 +326,8 @@ class RootPageObject(object):
             :param verbose: bool, whether to output additional logging
             :return: True if valid, else raise exception
         """
-        logger.info(f"\nAttempting to verify identity for '{self.name}': '{self.driver.current_url}'.")
+        logger.info(f"\nAttempting to verify identity for "
+                    f"'{self.name}': '{self.driver.current_url}'.")
 
         # set up list of validation results
         validations = []
@@ -449,7 +452,7 @@ class RootPageObject(object):
             console_logs['console'] = utils_selenium.\
                 get_console_logs(pageobject=self)
 
-            logger.info(f"Writing special logs.")
+            logger.info("Writing special logs.")
 
             # write the raw performance logs to /network
             utils_file.write_network_log_to_file(log=performance_logs,

--- a/welkin/data/applications.py
+++ b/welkin/data/applications.py
@@ -1,13 +1,12 @@
-import pytest
 import logging
 
 logger = logging.getLogger(__name__)
 
 """
-    Maps that app name and tier to the hostname string. 
-    
-    This is a contrived example because Welkin isn't testing 
-    any apps with multiple tiers. 
+    Maps that app name and tier to the hostname string.
+
+    This is a contrived example because Welkin isn't testing
+    any apps with multiple tiers.
 """
 app_tier_map = {
     'duckduckgo': {
@@ -28,5 +27,6 @@ def get_app_url_for_tier(app, tier):
         :return hostname: str, hostname
     """
     hostname = app_tier_map[app][tier]
-    logger.info(f"\nfound hostname '{hostname}' for app '{app}' on tier '{tier}'")
+    logger.info(f"\nfound hostname '{hostname}' "
+                f"for app '{app}' on tier '{tier}'")
     return hostname

--- a/welkin/data/users.py
+++ b/welkin/data/users.py
@@ -10,9 +10,9 @@ This user map is structured like this:
 <<tier>>
     |- <<appname>>
         |- <<framework user id, aka "fuid">>
-            |- details for this user 
+            |- details for this user
 
-This "path" is used to name and access the user passwords 
+This "path" is used to name and access the user passwords
 in the AWS ParameterStore. See integrations/aws/README_aws.md.
 """
 app_user_map = {

--- a/welkin/framework/checks.py
+++ b/welkin/framework/checks.py
@@ -1,11 +1,8 @@
 import logging
-from collections import namedtuple
 
-from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.common.exceptions import NoSuchElementException, TimeoutException
-from selenium.common.exceptions import StaleElementReferenceException
 
 logger = logging.getLogger(__name__)
 
@@ -82,7 +79,7 @@ def expect_element_to_be_gone(pageobject, check, waitfor=30):
     wait = WebDriverWait(pageobject.driver, waitfor)
 
     try:
-        this = pageobject.driver.find_element(check[1], check[2])
+        this = pageobject.driver.find_element(check[1], check[2])  # noqa: F841
         # good result!
         logger.info(f"\nUnload check '{check[1:]}' was not found.")
         try:
@@ -133,7 +130,7 @@ def check_url(pageobject):
         :return: bool, True if the check evaluated to True, else False
     """
     actual_url = pageobject.driver.current_url
-    if not pageobject.url in actual_url:
+    if pageobject.url not in actual_url:
         msg = f"Url inclusion check: expected '{pageobject.url}' " \
               f"to be inside '{actual_url}'."
         logger.error(msg)

--- a/welkin/framework/exceptions.py
+++ b/welkin/framework/exceptions.py
@@ -35,8 +35,9 @@ class JsonPayloadException(Exception):
 
 class UnexpectedStatusCodeException(Exception):
     """
-        Raise this exception when the server response code from an http request is not a success code.
-        Capture the requests response object and make that available.
+        Raise this exception when the server response code from an http
+        request is not a success code. Capture the requests response
+        object and make that available.
 
         # pass the response object to the exception
         >>> raise UnexpectedStatusCodeException(response=res)

--- a/welkin/framework/utils.py
+++ b/welkin/framework/utils.py
@@ -95,7 +95,7 @@ def strip_password_for_reporting(content):
     """
     if not content:
         # if there is no content, e.g. empty string, then nothing to strip!
-        logger.info(f"No password to strip.")
+        logger.info("No password to strip.")
         return content
     elif not content.get('Parameter'):
         # this is not a get parameter response, so nothing to strip

--- a/welkin/framework/utils_file.py
+++ b/welkin/framework/utils_file.py
@@ -168,8 +168,8 @@ def write_request_to_file(response, url, fname=''):
     boundary = None
     with open(path, 'a') as f:
         f.write(f"{url}\n\n")  # write the url as the first line
-        f.write(f"###### REQUEST ####### \n")
-        f.write(f"HEADERS\n")
+        f.write("###### REQUEST ####### \n")
+        f.write("HEADERS\n")
         try:
             # the request header MUST have the Content-Type key-value pair
             # if not, raise an exception and kill the test
@@ -190,8 +190,8 @@ def write_request_to_file(response, url, fname=''):
             if isinstance(response.request.body, bytes):
                 # this was a binary upload, so decode it as a
                 # unicode str in order to write it to the file
-                logger.warning(f"response.request.body cast as string.")
-                f.write(f"--decoded from bytes--\n")
+                logger.warning("response.request.body cast as string.")
+                f.write("--decoded from bytes--\n")
                 if boundary:
                     # this is a multi-part form body
                     # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Disposition
@@ -199,25 +199,25 @@ def write_request_to_file(response, url, fname=''):
                     cleaned_body = body.replace('\r\n\r\n\n\r\n', '\n\n')
                     f.write(cleaned_body)
                 else:
-                    f.write(f"don't know what happened with this request body;\n"
-                            f"probably a POST with bytes.")
+                    f.write("don't know what happened with this request body;\n"
+                            "probably a POST with bytes.")
 
             else:
                 try:
                     f.write(utils.plog(json.loads(response.request.body)))
                 except UnicodeDecodeError:
-                    logger.warning(f"got UnicodeDecodeError.")
-                    f.write(f"-- byte string snipped --")
+                    logger.warning("got UnicodeDecodeError.")
+                    f.write("-- byte string snipped --")
                 except json.decoder.JSONDecodeError:
-                    logger.warning(f"got json.decoder.JSONDecodeError.")
+                    logger.warning("got json.decoder.JSONDecodeError.")
                     f.write(utils.plog(response.request.body))
 
-        f.write(f"\n\n###### RESPONSE ####### \n")
-        f.write(f"HEADERS\n")
+        f.write("\n\n###### RESPONSE ####### \n")
+        f.write("HEADERS\n")
         f.write(utils.plog(response.headers))
-        f.write(f"\n\nRESPONSE STATUS CODE\n")
+        f.write("\n\nRESPONSE STATUS CODE\n")
         f.write(f"response server status: {response.status_code}")
-        f.write(f"\n\nPAYLOAD\n")
+        f.write("\n\nPAYLOAD\n")
         try:
             f.write(utils.plog(response.json()))
         except json.decoder.JSONDecodeError:

--- a/welkin/framework/utils_selenium.py
+++ b/welkin/framework/utils_selenium.py
@@ -162,7 +162,7 @@ def clear_local_storage(pageobject):
 
     # run the script
     pageobject.driver.execute_script(script)
-    logger.warning(f"localStorage has been cleared")
+    logger.warning("localStorage has been cleared")
 
 
 def get_session_storage(pageobject):
@@ -189,7 +189,7 @@ def get_session_storage(pageobject):
     except WebDriverException:
         # checking for storage immediately after the driver is
         # loaded will throw a WebDriverException, so ignore that
-        msg = f"Ignoring a WebDriverException."
+        msg = "Ignoring a WebDriverException."
         logger.warning(msg)
         return content
 
@@ -206,7 +206,7 @@ def clear_session_storage(pageobject):
 
     # run the script
     pageobject.driver.execute_script(script)
-    logger.warning(f"sessionStorage has been cleared")
+    logger.warning("sessionStorage has been cleared")
 
 
 def hard_clear_input_field(pageobject, element, name):
@@ -228,7 +228,7 @@ def hard_clear_input_field(pageobject, element, name):
         :return element: webelement (after being cleared)
     """
     driver = pageobject.driver
-    logger.warning(f"getting serious about clearing the default")
+    logger.warning("getting serious about clearing the default")
     current_value = element.get_attribute('value')
     value_length = len(current_value) + 1
     logger.info(f"\nneed to unset '{current_value}'; {value_length} chars")

--- a/welkin/framework/utils_webstorage.py
+++ b/welkin/framework/utils_webstorage.py
@@ -1,10 +1,7 @@
 from copy import deepcopy
-import deepdiff
-import dpath.util
 import json
 import logging
 
-from welkin.framework import utils
 
 logger = logging.getLogger(__name__)
 

--- a/welkin/models/user.py
+++ b/welkin/models/user.py
@@ -119,10 +119,10 @@ class ApplicationUser():
         """
         properties = self.__dict__
         keys = properties.keys()
-        if not 'password' in keys:
+        if 'password' not in keys:
             return f"ApplicationUser({properties})"
         else:
             cleaned_keys = [k for k in keys if not k == 'password']
-            cleaned_props = {k:properties[k] for k in cleaned_keys}
+            cleaned_props = {k: properties[k] for k in cleaned_keys}
             cleaned_props['password'] = 'value redacted'
             return f"ApplicationUser({cleaned_props})"

--- a/welkin/setup.cfg
+++ b/welkin/setup.cfg
@@ -1,0 +1,3 @@
+[flake8]
+exclude .git
+max-line-length = 95

--- a/welkin/tests/configs.py
+++ b/welkin/tests/configs.py
@@ -30,4 +30,3 @@ def environment(request):
         return 'http://127.0.0.1:8000'
     else:
         raise ValueError('Not a valid environment.')
-

--- a/welkin/tests/conftest.py
+++ b/welkin/tests/conftest.py
@@ -5,7 +5,6 @@ import sys
 from pathlib import Path
 
 from welkin.framework import utils
-from welkin.data.applications import get_app_url_for_tier as get_app_url
 
 logger = logging.getLogger(__name__)
 # setting up the log file filenames
@@ -79,11 +78,11 @@ def pytest_configure(config):
 def pytest_sessionstart(session):
     """
         Set up the test run.
-        
+
         Use configure_pytest_session() for any global test session and
         fixture logic.
 
-        :param session: pytest request object (which is the context 
+        :param session: pytest request object (which is the context
                         of the calling text method)
         :return: None
     """
@@ -101,7 +100,7 @@ def pytest_collection_modifyitems(items):
         :param items: list, list of test item objects
         :return: None
     """
-    logger.info(f"no actions taken.")
+    logger.info("no actions taken.")
 
 
 # 4.0
@@ -113,7 +112,7 @@ def pytest_collection_finish(session):
         :param session: pytest Session object
         :return: None
     """
-    logger.info(f"no actions taken.")
+    logger.info("no actions taken.")
     # logger.info(f"\nsession.__dict__:\n{utils.plog(session.__dict__)}")
 
 
@@ -205,7 +204,7 @@ def pytest_runtest_setup(item):
 
     # set up global namespace path-to-this-testcase value
     pytest.welkin_namespace['this_test'] = folder_path
-    logger.warning(f"### Changing log output path to the test case path. ###\n\n")
+    logger.warning("### Changing log output path to the test case path. ###\n\n")
 
     # redirect logging from the test run logger to the test case logger
     path_to_logfile = str(folder_path / TESTCASE_LOGFILE_NAME)
@@ -247,7 +246,7 @@ def pytest_runtest_setup(item):
             },
         }
     }
-    filename = set_logging_config(log_kwargs)
+    filename = set_logging_config(log_kwargs)  # noqa: F841
     yield
 
 
@@ -289,7 +288,7 @@ def pytest_runtest_teardown(item, nextitem):
         }
     }
 
-    logger.info(f"### Closing test case logfile ###\n\n")
+    logger.info("### Closing test case logfile ###\n\n")
     filename = set_logging_config(log_kwargs)
     logger.info(f"### Reset logfile to {filename} ###\n\n\n")
 
@@ -393,7 +392,7 @@ def initialize_logging():
             },
         }
     }
-    filename = set_logging_config(log_kwargs)
+    set_logging_config(log_kwargs)
     logger.info(pytest.welkin_namespace['testrun_output_path'])
     logger.info(f"\nnamespace:\n{utils.plog(pytest.welkin_namespace)}")
 
@@ -511,7 +510,7 @@ def auth():
         :return aws_session: AWS session object
     """
     # we currently use aws for managing test user account passwords
-    logger.info(f"\n\n=======> called auth()")
+    logger.info("\n\n=======> called auth()")
     return aws()
 
 
@@ -532,7 +531,7 @@ def set_up_testcase_reporting(path_to_subfolder, fixturenames):
     if '--collect-only' in sys.argv:
         # if pytest is invoked with the --collect-only option, don't
         # create the testrun subfolders
-        msg = f"Subfolders NOT created because this testrun is collect-only."
+        msg = "Subfolders NOT created because this testrun is collect-only."
         logger.info(msg)
     else:
         logger.info(f"fixturenames: {fixturenames}")
@@ -545,7 +544,7 @@ def set_up_testcase_reporting(path_to_subfolder, fixturenames):
         # method argument and have the appropriate folders and
         # logging in place.
         # #############################################
-        integrations = ['auth']  # not used, but helps with context
+        integrations = ['auth']  # not used, but helps with context  # noqa: F841
         web_apps = ['duckduckgo']
         apis = ['colourlovers', 'dadjokes', 'genderizer']
 
@@ -581,7 +580,8 @@ def set_up_testcase_reporting(path_to_subfolder, fixturenames):
         # create the screenshots logging folder for webapps
         folder_type = 'screenshots'
         if is_webapp:
-            screenshots_folder = str(utils.create_test_output_subfolder(output_path, folder_type))
+            screenshots_folder = \
+                str(utils.create_test_output_subfolder(output_path, folder_type))
             pytest.welkin_namespace[f"testrun_{folder_type}_output"] = screenshots_folder
             logger.info(f"created folder '{folder_type}': {screenshots_folder}")
         else:
@@ -590,7 +590,8 @@ def set_up_testcase_reporting(path_to_subfolder, fixturenames):
         # create the accessibility logging folder for webapps
         folder_type = 'accessibility'
         if is_webapp:
-            accessibility_folder = str(utils.create_test_output_subfolder(output_path, folder_type))
+            accessibility_folder = \
+                str(utils.create_test_output_subfolder(output_path, folder_type))
             pytest.welkin_namespace[f"testrun_{folder_type}_log_folder"] = accessibility_folder
             logger.info(f"created folder '{folder_type}': {accessibility_folder}")
         else:
@@ -601,7 +602,8 @@ def set_up_testcase_reporting(path_to_subfolder, fixturenames):
         # and by chromedriver for downloading files from the UI
         folder_type = 'downloads'
         if is_api or is_webapp:
-            downloads_folder = str(utils.create_test_output_subfolder(output_path, folder_type))
+            downloads_folder = \
+                str(utils.create_test_output_subfolder(output_path, folder_type))
             pytest.welkin_namespace[f"testrun_{folder_type}_log_folder"] = downloads_folder
             logger.info(f"created folder '{folder_type}': {downloads_folder}")
         else:
@@ -610,7 +612,8 @@ def set_up_testcase_reporting(path_to_subfolder, fixturenames):
         # set up handling for web storage for webapps
         folder_type = 'webstorage'
         if is_webapp:
-            webstorage_folder = str(utils.create_test_output_subfolder(output_path, folder_type))
+            webstorage_folder = \
+                str(utils.create_test_output_subfolder(output_path, folder_type))
             pytest.welkin_namespace[f"testrun_{folder_type}_log_folder"] = webstorage_folder
             logger.info(f"created folder '{folder_type}': {webstorage_folder}")
         else:
@@ -640,8 +643,8 @@ def set_up_testcase_reporting(path_to_subfolder, fixturenames):
             pytest.welkin_namespace['get_console'] = True
 
         else:
-            logger.info(f"did NOT create 'network' folder")
-            logger.info(f"did NOT create 'console' folder")
+            logger.info("did NOT create 'network' folder")
+            logger.info("did NOT create 'console' folder")
             pytest.welkin_namespace['devtools_supported'] = False
             pytest.welkin_namespace['get_network'] = False
             pytest.welkin_namespace['get_console'] = False
@@ -694,8 +697,8 @@ def browser_chrome():
     from selenium import webdriver
     from selenium.webdriver.chrome.options import Options
 
-    chrome_options = Options()
-    #default_dir = {'download.default_directory': None#}
+    chrome_options = Options()  # noqa: F841
+    # default_dir = {'download.default_directory': None#}
     # chrome_options.add_experimental_option('prefs')
 
     capabilities = base_chrome_capabilities()
@@ -715,7 +718,7 @@ def browser_chrome_headless():
 
     chrome_options = Options()
     chrome_options.add_argument('--headless')
-    #default_dir = {'download.default_directory': None#}
+    # default_dir = {'download.default_directory': None#}
     # chrome_options.add_experimental_option('prefs')
 
     capabilities = base_chrome_capabilities()
@@ -743,7 +746,6 @@ def driver(request, browser):
         :yield driver: webdriver object
     """
     logger.info(f"Requested '{browser}' driver.")
-    from selenium import webdriver
     driver = None
 
     if browser == 'chrome':
@@ -801,7 +803,7 @@ def aws():
 
         :return aws_session: AWS session object
     """
-    logger.info(f"\n\n=======> called aws()")
+    logger.info("\n\n=======> called aws()")
     from welkin.integrations.aws.aws import AWSSession
     # create a session object tied to the local default config
     # for region and IAM user

--- a/welkin/tests/examples/test_api_colors.py
+++ b/welkin/tests/examples/test_api_colors.py
@@ -1,6 +1,5 @@
 import pytest
 import logging
-import json
 import time
 
 from welkin.framework import utils
@@ -42,8 +41,8 @@ class ExampleColourLoversTests(object):
 
     def test_get_colors(self, colourlovers):
         """
-            Simple test for the "colors" endpoint, using no data. This just looks at the structure
-            of the returned json.
+            Simple test for the "colors" endpoint, using no data. This just
+            looks at the structure of the returned json.
 
             :return: None
         """

--- a/welkin/tests/examples/test_api_genderize.py
+++ b/welkin/tests/examples/test_api_genderize.py
@@ -23,8 +23,8 @@ class ExampleGenderizerTests(object):
                              ids=[n[0] for n in good_names_single])
     def test_get_single_name(self, genderizer, good_name):
         """
-            For the supplied name and expected gender, verify that the API response
-            contains the name and expected gender.
+            For the supplied name and expected gender, verify that the API
+            response contains the name and expected gender.
 
             :param good_name: tuple, str name and str gender
             :return: None
@@ -41,8 +41,9 @@ class ExampleGenderizerTests(object):
         logger.info(utils.plog(res.json()))
 
         # test point: verify that we get back the same name that we requested
-        assert res.json()['name'] == expected_name, 'expected "%s", but got "%s"' \
-                                           % (expected_name, res.json()['name'])
+        assert res.json()['name'] == expected_name, \
+            'expected "%s", but got "%s"' \
+            % (expected_name, res.json()['name'])
 
         # test point: verify that we got the expected gender assignment
         assert api.got_gender(res, ex_gender)
@@ -73,7 +74,8 @@ class ExampleGenderizerTests(object):
         assert res.status_code == 200
         logger.info(utils.plog(res.json()))
 
-        # convert the param from list of names + list of genders to list of name + gender pairs
+        # convert the param from list of names + list of genders
+        # to list of name + gender pairs
         expected = list(zip(multiple_good_names[0], multiple_good_names[1]))
         logger.info('expected: %s' % expected)
 
@@ -89,17 +91,20 @@ class ExampleGenderizerTests(object):
         assert api.validate_schema(res.json()[0], verbose=True)
 
         # test point: verify a results item for each name passed to the API
-        assert len(expected) == len(actual), 'FAIL: got %s results but expected %s.' \
-                                             % (len(actual), len(expected))
+        assert len(expected) == len(actual), \
+            'FAIL: got %s results but expected %s.' \
+            % (len(actual), len(expected))
 
         # loop over the results and validate each name/gender pair
         for i, item in enumerate(actual):
 
             # test point: verify that we get back the same name that we requested
-            assert item[0] == expected[i][0], 'expected "%s", but got "%s"' % (expected[i][0], item[0])
+            assert item[0] == expected[i][0], \
+                'expected "%s", but got "%s"' % (expected[i][0], item[0])
 
             # test point: verify the expected gender for the name
-            assert item[1] == expected[i][1], 'expected "%s", but got "%s"' % (expected[i][1], item[1])
+            assert item[1] == expected[i][1], \
+                'expected "%s", but got "%s"' % (expected[i][1], item[1])
 
     @pytest.mark.parametrize('bad_name', [n for n in bad_names_single])
     def test_gender_not_resolved(self, genderizer, bad_name):
@@ -112,7 +117,6 @@ class ExampleGenderizerTests(object):
         """
         api = self.gender_endpoint
         name = bad_name
-        expected_name = bad_name
         ex_gender = None
 
         res = api.get_gender(name, verbose=True)
@@ -147,7 +151,8 @@ class ExampleGenderizerTests(object):
         assert res.status_code == 200
         logger.info(utils.plog(res.json()))
 
-        # convert the param from list of names + list of genders to list of name + gender pairs
+        # convert the param from list of names + list of genders
+        # to list of name + gender pairs
         expected = list(zip(multiple_bad_names[0], multiple_bad_names[1]))
         logger.info('expected: %s' % expected)
 
@@ -159,17 +164,20 @@ class ExampleGenderizerTests(object):
         assert api.verify_keys_in_response(res.json()[0].keys())
 
         # test point: verify a results item for each name passed to the API
-        assert len(expected) == len(actual), 'FAIL: got %s results but expected %s.' \
-                                             % (len(actual), len(expected))
+        assert len(expected) == len(actual), \
+            'FAIL: got %s results but expected %s.' \
+            % (len(actual), len(expected))
 
         # loop over the results and validate each name/gender pair
         for i, item in enumerate(actual):
 
             # test point: verify that we get back the same name that we requested
-            assert item[0] == expected[i][0], 'expected "%s", but got "%s"' % (expected[i][0], item[0])
+            assert item[0] == expected[i][0], \
+                'expected "%s", but got "%s"' % (expected[i][0], item[0])
 
             # test point: verify the expected gender for the name
-            assert item[1] == expected[i][1], 'expected "%s", but got "%s"' % (expected[i][1], item[1])
+            assert item[1] == expected[i][1], \
+                'expected "%s", but got "%s"' % (expected[i][1], item[1])
 
     def test_int_as_name(self, genderizer):
         """
@@ -194,14 +202,15 @@ class ExampleGenderizerTests(object):
                              ids=['+'.join(l[0]) for l in too_many_names])
     def test_exceed_multiple_request_limit(self, genderizer, more_than_11_names):
         """
-            Request 11 names in one API call; the limit is 10 so any name after the tenth gets ignored.
+            Request 11 names in one API call; the limit is 10 so any
+            name after the tenth gets ignored.
 
-            :param more_than_11_names: tuple, list of str names and list of str genders
+            :param more_than_11_names: tuple, list of str names and
+            list of str genders
             :return: None
         """
         api = self.gender_endpoint
         name = list(more_than_11_names[0])  # needs to be a list
-        expected_name = more_than_11_names[0]
         logger.info(f"\n----> name: {name}")
 
         res = api.get_gender(name, verbose=True)
@@ -210,8 +219,10 @@ class ExampleGenderizerTests(object):
         assert res.status_code == 200
         logger.info(utils.plog(res.json()))
 
-        # convert the param from list of names + list of genders to list of name + gender pairs
-        expected = list(zip(more_than_11_names[0], more_than_11_names[1]))[:10]  # keep list to ten
+        # convert the param from list of names + list of genders
+        # to list of name + gender pairs
+        expected = list(zip(more_than_11_names[0],
+                            more_than_11_names[1]))[:10]  # keep list to ten
         logger.info('expected: %s' % expected)
 
         # convert the returned json into a list of name + gender pairs
@@ -222,14 +233,17 @@ class ExampleGenderizerTests(object):
         assert api.verify_keys_in_response(res.json()[0].keys())
 
         # test point: verify a results item for each name passed to the API
-        assert len(expected) == len(actual), 'FAIL: got %s results but expected %s.' \
-                                             % (len(actual), len(expected))
+        assert len(expected) == len(actual), \
+            'FAIL: got %s results but expected %s.' \
+            % (len(actual), len(expected))
 
         # loop over the results and validate each name/gender pair
         for i, item in enumerate(actual):
 
             # test point: verify that we get back the same name that we requested
-            assert item[0] == expected[i][0], 'expected "%s", but got "%s"' % (expected[i][0], item[0])
+            assert item[0] == expected[i][0], \
+                'expected "%s", but got "%s"' % (expected[i][0], item[0])
 
             # test point: verify the expected gender for the name
-            assert item[1] == expected[i][1], 'expected "%s", but got "%s"' % (expected[i][1], item[1])
+            assert item[1] == expected[i][1], \
+                'expected "%s", but got "%s"' % (expected[i][1], item[1])

--- a/welkin/tests/examples/test_dadjokes.py
+++ b/welkin/tests/examples/test_dadjokes.py
@@ -1,9 +1,6 @@
 import pytest
 import logging
-import json
-import time
 
-from welkin.framework import utils
 from welkin.apps.examples.dadjokes_api.api import SearchEndpoint
 
 logger = logging.getLogger(__name__)

--- a/welkin/tests/examples/test_duckduckgo.py
+++ b/welkin/tests/examples/test_duckduckgo.py
@@ -82,8 +82,8 @@ class ExampleDuckduckgoTests(object):
 
         # validate expectations
         if not (actual_title == expected_title and actual_url == expected_url):
-            msg1 = f"ERROR: DuckDuckGo search results page did NOT " \
-                   f"self-validate identity. "
+            msg1 = "ERROR: DuckDuckGo search results page did NOT " \
+                   "self-validate identity. "
             msg2 = f"Expected '{expected_title}' + '{expected_url}', " \
                    f"got '{actual_title}' + '{actual_url}'."
             logger.error(msg1 + msg2)
@@ -157,7 +157,8 @@ class ExampleDuckduckgoTests(object):
                 if token.lower() in title.lower():
                     raw_relevant_results.append(title)
         relevant_results = list(set(raw_relevant_results))  # de-dupe
-        logger.info(f"\n{len(relevant_results)} relevant results:\n{utils.plog(relevant_results)}")
+        logger.info(f"\n{len(relevant_results)} relevant "
+                    f"results:\n{utils.plog(relevant_results)}")
         assert len(relevant_results) > 5, \
             f"Only {len(relevant_results)} relevant results found, hoped for 5"
 
@@ -203,7 +204,8 @@ class ExampleDuckduckgoTests(object):
                 if token.lower() in title.lower():
                     raw_relevant_results.append(title)
         relevant_results = list(set(raw_relevant_results))  # de-dupe
-        logger.info(f"\n{len(relevant_results)} relevant results:\n{utils.plog(relevant_results)}")
+        logger.info(f"\n{len(relevant_results)} relevant "
+                    f"results:\n{utils.plog(relevant_results)}")
         assert len(relevant_results) > 5, \
             f"Only {len(relevant_results)} relevant results found, hoped for 5"
 
@@ -246,6 +248,7 @@ class ExampleDuckduckgoTests(object):
                 if token.lower() in title.lower():
                     raw_relevant_results.append(title)
         relevant_results = list(set(raw_relevant_results))  # de-dupe
-        logger.info(f"\n{len(relevant_results)} relevant results:\n{utils.plog(relevant_results)}")
+        logger.info(f"\n{len(relevant_results)} relevant "
+                    f"results:\n{utils.plog(relevant_results)}")
         assert len(relevant_results) > 5, \
             f"Only {len(relevant_results)} relevant results found, hoped for 5"

--- a/welkin/tests/examples/test_examples.py
+++ b/welkin/tests/examples/test_examples.py
@@ -9,29 +9,34 @@ class ExampleTests(object):
 
     def test_simple_pass(self):
         """
-            A simple test method that looks for the presence of a string in a list of strings.
+            A simple test method that looks for the presence of a string
+            in a list of strings.
 
             :return: None
         """
         testdata = ['apple', 'pear', 'berry']
         expected_element = 'berry'
         logger.info('Looking for "%s".' % expected_element)
-        assert expected_element in testdata, 'FAIL: "%s" not in "%s".' % (expected_element, testdata)
+        assert expected_element in testdata, \
+            'FAIL: "%s" not in "%s".' % (expected_element, testdata)
 
     def test_simple_fail(self):
         """
-            A simple test method that looks for the presence of a string in a list of strings, but fails.
+            A simple test method that looks for the presence of a string
+            in a list of strings, but fails.
 
             :return: None
         """
         testdata = ['apple', 'pear', 'berry']
         expected_element = 'cherry'
         logger.info('Looking for "%s".' % expected_element)
-        assert expected_element in testdata, 'FAIL: "%s" not in "%s".' % (expected_element, testdata)
+        assert expected_element in testdata, \
+            'FAIL: "%s" not in "%s".' % (expected_element, testdata)
 
     def test_simple_error(self):
         """
-            A simple test method that demonstrates that a non-assertion exception is considered as a FAIL.
+            A simple test method that demonstrates that a non-assertion
+            exception is considered as a FAIL.
 
             :return: None
         """
@@ -44,8 +49,9 @@ class ExampleTests(object):
                                       pytest.mark.xfail('kumquat')])
     def test_parametrized(self, fruit):
         """
-            A parametrized test method that looks for the presence of a string in a list of strings.
-            A test instance is created for each parameter in the supplied list; one of these instances
+            A parametrized test method that looks for the presence of a
+            string in a list of strings. A test instance is created for
+            each parameter in the supplied list; one of these instances
             will fail.
 
             :param fruit: str, item in the parametrized list to test for
@@ -54,11 +60,13 @@ class ExampleTests(object):
         testdata = ['apple', 'pear', 'berry']
         expected_element = fruit
         logger.info('Looking for "%s".' % expected_element)
-        assert expected_element in testdata, 'FAIL: "%s" not in "%s".' % (expected_element, testdata)
+        assert expected_element in testdata, \
+            'FAIL: "%s" not in "%s".' % (expected_element, testdata)
 
     def test_zero_division(self):
         """
-            Looking for the correct exception to be raised when dividing by zero.
+            Looking for the correct exception to be raised when
+            dividing by zero.
 
             :return: None
         """


### PR DESCRIPTION
requirements.txt
+ added flake8 >= 3.9.2

setup.cfg
+ added file to house flake8 config

README.md
+ added instructions for running Flake8

minor lint-related changes to the following 27 files:
+ apps/examples/colourlovers_api/base_endpoint.py
+ apps/examples/colourlovers_api/color.py
+ apps/examples/colourlovers_api/colors.py
+ apps/examples/dadjokes_api/api.py
+ apps/examples/data.py
+ apps/examples/duckduckgo/base_page.py
+ apps/examples/duckduckgo/noauth/pages.py
+ apps/examples/genderize/api.py
+ apps/examples/genderize/genderize_data.py
+ apps/root_endpoint.py
+ apps/root_pageobject.py
+ data/applications.py
+ data/users.py
+ framework/checks.py
+ framework/exceptions.py
+ framework/utils.py
+ framework/utils_file.py
+ framework/utils_selenium.py
+ framework/utils_webstorage.py
+ models/user.py
+ tests/configs.py
+ tests/conftest.py
+ tests/examples/test_api_colors.py
+ tests/examples/test_api_genderize.py
+ tests/examples/test_dadjokes.py
+ tests/examples/test_duckduckgo.py
+ tests/examples/test_examples.py