### PR TITLE
issue 59: refactor namespace data population

### DIFF
--- a/welkin/apps/root_pageobject.py
+++ b/welkin/apps/root_pageobject.py
@@ -443,7 +443,7 @@ class RootPageObject(object):
         fname = filename if filename else self.name
         clean_name = utils.path_proof_name(fname)
 
-        if pytest.welkin_namespace['devtools_supported']:
+        if pytest.custom_namespace['devtools_supported']:
             # get the logs
             performance_logs = utils_selenium.\
                 get_network_traffic_logs(pageobject=self)
@@ -464,7 +464,7 @@ class RootPageObject(object):
 
         else:
             logger.warning(f"Cannot access chrome logs for "
-                           f"{pytest.welkin_namespace['browser']}.")
+                           f"{pytest.custom_namespace['browser']}.")
 
     def save_webstorage(self, event, set_this_event=True):
         """
@@ -528,7 +528,7 @@ class RootPageObject(object):
         fname = filename if filename else self.name
 
         # write the results to a file
-        path = pytest.welkin_namespace['testrun_accessibility_log_folder']
+        path = pytest.custom_namespace['testrun_accessibility_log_folder']
         filename = f"{path}/{utils.path_proof_name(fname)}.json"
         logger.info(f"Writing accessibility logs to {filename}")
         axe.write_results(axe_results, filename)

--- a/welkin/framework/exceptions.py
+++ b/welkin/framework/exceptions.py
@@ -1,5 +1,5 @@
 """
-    Custom Welkin exceptions, managed in one place.
+    Custom exceptions, managed in one place.
 """
 import logging
 

--- a/welkin/framework/utils_file.py
+++ b/welkin/framework/utils_file.py
@@ -19,7 +19,7 @@ def write_cookies_to_file(cookies, url, fname=''):
         :return: None
     """
     filename = f"/{time.strftime('%H%M%S')}_{utils.path_proof_name(fname)}.txt"
-    path = pytest.welkin_namespace['testrun_cookies_output'] + filename
+    path = pytest.custom_namespace['testrun_cookies_output'] + filename
     with open(path, 'w') as f:
         f.write(f"{url}\n")  # write the url as the first line
         f.write(utils.plog(cookies))
@@ -39,7 +39,7 @@ def write_network_log_to_file(log, url, fname=''):
     # note: json files don't allow comments, so we'd not be able
     # to write the url to the file
     filename = f"/{time.strftime('%H%M%S')}_{utils.path_proof_name(fname)}.json"
-    path = pytest.welkin_namespace['testrun_network_log_folder'] + filename
+    path = pytest.custom_namespace['testrun_network_log_folder'] + filename
 
     wrapper = {}
     wrapper['_page'] = url
@@ -60,7 +60,7 @@ def write_console_log_to_file(log, url, fname=''):
         :return: None
     """
     filename = f"/{time.strftime('%H%M%S')}_{utils.path_proof_name(fname)}.json"
-    path = pytest.welkin_namespace['testrun_console_log_folder'] + filename
+    path = pytest.custom_namespace['testrun_console_log_folder'] + filename
 
     # add key/value for the page url
     log.update({'_page': url})
@@ -87,7 +87,7 @@ def write_webstorage_to_files(data, current_url, pageobject_name,
     """
     base_filename = f"/{time.strftime('%H%M%S')}_" \
                     f"{utils.path_proof_name(event)}"
-    path = pytest.welkin_namespace['testrun_webstorage_log_folder'] + base_filename
+    path = pytest.custom_namespace['testrun_webstorage_log_folder'] + base_filename
 
     # unpack the data
     local_storage, session_storage = data
@@ -164,7 +164,7 @@ def write_request_to_file(response, url, fname=''):
         :return: None
     """
     filename = f"/{time.strftime('%H%M%S')}_{utils.path_proof_name(fname)}.txt"
-    path = pytest.welkin_namespace['testrun_requests_log_folder'] + filename
+    path = pytest.custom_namespace['testrun_requests_log_folder'] + filename
     boundary = None
     with open(path, 'a') as f:
         f.write(f"{url}\n\n")  # write the url as the first line
@@ -244,6 +244,6 @@ def write_sdk_response_to_file(response, sdk_app, fname=''):
         :return: None
     """
     filename = f"/{time.strftime('%H%M%S')}_{utils.path_proof_name(fname)}.json"
-    path = pytest.welkin_namespace['testrun_integrations_log_folder'] + filename
+    path = pytest.custom_namespace['testrun_integrations_log_folder'] + filename
     with open(path, 'a') as f:
         f.write(utils.plog(response))

--- a/welkin/framework/utils_selenium.py
+++ b/welkin/framework/utils_selenium.py
@@ -24,10 +24,10 @@ def take_and_save_screenshot(driver, filename=''):
     filename = '%s_%s.png' % (time.strftime('%H%M%S'), filename.replace(' ', '_'))
 
     # Note: the path depends on the current test case!
-    path = f"{str(pytest.welkin_namespace['testrun_screenshots_output'])}/{filename}"
+    path = f"{str(pytest.custom_namespace['testrun_screenshots_output'])}/{filename}"
 
     # full-screen screenshots are enabled by
-    if pytest.welkin_namespace['browser'] in ['firefox', 'safari']:
+    if pytest.custom_namespace['browser'] in ['firefox', 'safari']:
         body = driver.find_element_by_tag_name('body')
         body_png = body.screenshot_as_png
         with open(path, 'wb') as file:
@@ -51,7 +51,7 @@ def get_and_save_source(driver, filename=''):
     filename = '/%s_%s.html' % (time.strftime('%H%M%S'), filename.replace(' ', '_'))
 
     # Note: the path depends on the current test case!
-    path = f"{str(pytest.welkin_namespace['this_test'])}/{filename}"
+    path = f"{str(pytest.custom_namespace['this_test'])}/{filename}"
 
     with open(path, 'w') as f:
         f.write(driver.page_source)

--- a/welkin/tests/integrations/test_aws_integration.py
+++ b/welkin/tests/integrations/test_aws_integration.py
@@ -5,7 +5,7 @@ from welkin.framework import utils
 from welkin.models.user import ApplicationUser
 from welkin.integrations.aws.aws import AWSSession, AWSClient
 
-TIER = pytest.welkin_namespace.get('tier')
+TIER = pytest.custom_namespace.get('tier')
 logger = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
framework/exceptions.py
+ deleted "Welkin" from the docstring

tests/conftest.py
+ added update_namespace()
+ refactored pytest_configure() to use update_namespace()
+ refactored pytest_runtest_setup() to use update_namespace()
+ refactored initialize_logging() to use update_namespace()
+ refactored add_opts_to_namespace() to use update_namespace()
+ refactored set_up_testcase_reporting() to use update_namespace()

renamed "welkin_namespace" to "custom_namespace" in the following files:
+ apps/root_pageobject.py
+ framework/utils_file.py
+ framework/utils_selenium.py
+ tests/conftest.py
+ tests/integrations/test_aws_integration.py