### PR TITLE
issue 62: update duckduckgo wrapper & tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,5 @@ flake8 >= 3.9.2
 pytest >= 6.2.5
 pytest-html >= 1.14.2
 pytest-instafail >= 0.3.0
-requests >= 2.26.0
-selenium == 4.0.0
+requests >= 2.28.2
+selenium == 4.8.3

--- a/welkin/apps/examples/duckduckgo/routings.py
+++ b/welkin/apps/examples/duckduckgo/routings.py
@@ -4,9 +4,14 @@ AUTH_PATH = None  # not implemented for this wrapper
 
 # mapping page object names to classes
 noauth_pageobjects = {
-    'duckduckgo home page': {
+    'duckduckgo external home page': {
         'module': 'pages',
-        'object': 'HomePage',
+        'object': 'ExternalHomePage',
+        'path': NOAUTH_PATH
+    },
+    'duckduckgo internal home page': {
+        'module': 'pages',
+        'object': 'InternalHomePage',
         'path': NOAUTH_PATH
     },
     'duckduckgo search results page': {

--- a/welkin/apps/examples/duckduckgo_limited/limited_pages.py
+++ b/welkin/apps/examples/duckduckgo_limited/limited_pages.py
@@ -21,9 +21,19 @@ class BasePageObject(object):
             :param text: str, query string
             :return: None
         """
-        sel_search_form = 'js-search-input'
+        # different pages have different search form selectors; grab every
+        # element with an id that starts with "search"
+        possible_elements = self.driver.find_elements(By.CSS_SELECTOR, '[id^=search')
+        sel_search_form = None
+        for e in possible_elements:
+            # find the *first* id that ends with 'input'
+            this_id = e.get_property('id')
+            if this_id.endswith('input'):
+                sel_search_form = this_id
+                break
+
         # grab the search field
-        search_input = self.driver.find_element(By.CLASS_NAME, sel_search_form)
+        search_input = self.driver.find_element(By.ID, sel_search_form)
 
         # pass in the search string
         search_input.send_keys(text)
@@ -93,21 +103,21 @@ class SearchResultsPage(BasePageObject):
         """
         # set expectations
         expected_title = f"{self.search_text} at {self.appname}"
-        expected_url = f"https://{self.domain}/?q={self.search_text.replace(' ', '+')}"
+        expected_escaped_query = f"q={self.search_text.replace(' ', '+')}"
 
         # actual results
         actual_title = self.driver.title
         actual_url = self.driver.current_url
 
         # validate expectations
-        if actual_title == expected_title and actual_url.startswith(expected_url):
+        if actual_title == expected_title and expected_escaped_query in actual_url:
             msg = f"{self.appname} search results page self-validated identity."
             logger.info(msg)
             return True
         else:
             msg1 = f"FAIL: {self.appname} search results page did NOT " \
                    f"self-validate identity. "
-            msg2 = f"Expected '{expected_title}' + '{expected_url}', " \
+            msg2 = f"Expected '{expected_title}' + '{expected_escaped_query}', " \
                    f"got '{actual_title}' + '{actual_url}'."
             logger.error(msg1 + msg2)
             raise PageIdentityException(msg1 + msg2)
@@ -118,8 +128,8 @@ class SearchResultsPage(BasePageObject):
 
             :return result_titles: list, str titles for each returned result
         """
-        sel_result_items = 'js-result-title-link'
-        raw_results = self.driver.find_elements(By.CLASS_NAME, sel_result_items)
+        sel_result_items = 'article div:nth-child(2)'
+        raw_results = self.driver.find_elements(By.CSS_SELECTOR, sel_result_items)
         result_titles = [item.text for item in raw_results]
         logger.info(f"\nSearch results item titles:\n{utils.plog(result_titles)}")
         return result_titles


### PR DESCRIPTION
requirements.txt
+ updated requests & selenium versions

apps/examples/duckduckgo/routings.py
+ split 'duckduckgo home page' into two entries 'duckduckgo external home page' and 'duckduckgo internal home page'

apps/examples/duckduckgo/noauth/pages.py
+ updated all page object classes

apps/examples/duckduckgo_simple/simple_pages.py
+ updated all POM classes

apps/examples/duckduckgo_limited/limited_pages.py
+ updated all POM classes

tests/examples/test_duckduckgo.py
+ updated test_duckduckgo_router() to start the flow by instantiating the ExternalHomePage class
+ updated test_duckduckgo_brittle()
+ updated test_duckduckgo_limited()
+ updated test_duckduckgo_simple()