### PR TITLE
issue 66: support browser metrics collection

### DIFF
--- a/welkin/framework/utils_file.py
+++ b/welkin/framework/utils_file.py
@@ -49,6 +49,29 @@ def write_network_log_to_file(log, url, fname=''):
     logger.info(f"\nSaved browser network log: {path}.")
 
 
+def write_metrics_log_to_file(log, url, fname=''):
+    """
+        Save the browser metrics log as json to a file. 
+        
+        :param log: dict, browser metrics log
+        :param url: str, url for the current page
+        :param fname: str, first part of filename, will be appended with
+                           timestamp; defaults to empty string
+        :return: 
+    """
+    # note: json files don't allow comments, so we'd not be able
+    # to write the url to the file. Instead, insert a kv pair into dict
+    filename = f"/{time.strftime('%H%M%S')}_{utils.path_proof_name(fname)}.json"
+    path = pytest.custom_namespace['testrun_metrics_log_folder'] + filename
+
+    wrapper = {}
+    wrapper['_page'] = url
+    wrapper.update(log)
+    with open(path, 'a') as f:
+        f.write(utils.plog(wrapper))
+    logger.info(f"\nSaved browser metrics log: {path}.")
+
+
 def write_console_log_to_file(log, url, fname=''):
     """
         Write the chrome devtools console logs to a file.

--- a/welkin/framework/utils_selenium.py
+++ b/welkin/framework/utils_selenium.py
@@ -115,6 +115,21 @@ def get_network_traffic_logs(pageobject):
     return jlogs
 
 
+def get_metrics_log(pageobject):
+    """
+        Get the metrics log for the current page from the browser.
+
+        :param pageobject: page object instance
+        :return metrics: dict
+    """
+    driver = pageobject.driver
+    url = pageobject.url
+    fname = pageobject.name
+
+    logger.info(f"\nGetting metrics log for page '{fname}' at {url}.")
+    metrics = driver.execute_cdp_cmd('Performance.getMetrics', {})
+    return metrics
+
 def get_webstorage(pageobject):
     """
         Wrapper to call methods to get browser local and session storage

--- a/welkin/tests/conftest.py
+++ b/welkin/tests/conftest.py
@@ -689,12 +689,21 @@ def set_up_testcase_reporting(path_to_subfolder, fixturenames):
             logger.info(f"created folder '{folder_type}': {console_folder}")
             namespace_data['get_console'] = True
 
+            # create the browser metrics logs folder (for all right now)
+            folder_type = 'metrics'
+            metrics_folder = str(utils.create_test_output_subfolder(output_path, folder_type))
+            namespace_data[f"testrun_{folder_type}_log_folder"] = metrics_folder
+            logger.info(f"created folder '{folder_type}': {console_folder}")
+            namespace_data['get_metrics'] = True
+
         else:
             logger.info("did NOT create 'network' folder")
             logger.info("did NOT create 'console' folder")
+            logger.info("did NOT create 'metrics' folder")
             namespace_data['devtools_supported'] = False
             namespace_data['get_network'] = False
             namespace_data['get_console'] = False
+            namespace_data['get_metrics'] = False
 
         # update our hacky namespace
         update_namespace(namespace_data, verbose=True)
@@ -729,6 +738,7 @@ def base_chrome_capabilities():
     from selenium.webdriver.chrome.options import Options
 
     options = Options()
+    # enable collection of network logging
     options.set_capability('goog:loggingPrefs', {'performance': 'ALL'})
     return options
 
@@ -792,6 +802,8 @@ def driver(request, browser):
     # be over-rideable with explicit local waits
     # driver.implicitly_wait(10)  # default wait for 10 seconds
     user_agent = driver.execute_script("return navigator.userAgent;")
+    # enable collection of performance metrics
+    driver.execute_cdp_cmd('Performance.enable', {})
 
     if browser in ['chrome', 'headless_chrome']:
         driver_version = driver.capabilities['chrome']['chromedriverVersion']


### PR DESCRIPTION
tests/conftest.py
+ updated driver() to enable metrics collection for chrome
+ updated set_up_testcase_reporting() to support new metrics folder

apps/root_pageobject.py
+ update load_pageobject() with a call to save_browser_metrics()
+ add save_browser_metrics()

framework/utils_file.py
+ added write_metrics_log_to_file()

framework/utils_selenium.py
+ added get_metrics_log()