### PR TITLE
issue 144: improve page load checking

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -12,7 +12,7 @@ filterwarnings = ignore::ResourceWarning
 # apparently this is expected behavior in python3 with sockets:
 # ResourceWarning: unclosed <socket.socket [closed] fd=14, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=6>
 
-addopts = -v --show-capture=no --html=output/report.html --self-contained-html
+addopts = -v --show-capture=no --html=output/report.html --self-contained-html --durations=5
 
 # console_output_style = progress
 

--- a/welkin/apps/README_pageobject_model.md
+++ b/welkin/apps/README_pageobject_model.md
@@ -23,15 +23,17 @@ Page objects themselves have _design patterns_.
 
 The typical package structure for a POM wrapper is:
 ```
-apps
+app name
     |- root_pageobject.py
     |- wrapper for app
         |- routings.py
         |- base_page.py
         |- noauth (for pages that do not require authentication)
-            |- base_noauth.py
+            |- base_noauth.py (functionality common to all noauth pages)
+            |- pages.py
         |- auth  (for pages that DO require authentication)
             |- base_auth.py
+            |- pages.py
 ```
 
 ### Hierarchical class structure

--- a/welkin/apps/sweetshop/noauth/pages.py
+++ b/welkin/apps/sweetshop/noauth/pages.py
@@ -15,6 +15,8 @@ class BasePage(NoAuthBasePageObject):
 
 class HomePage(BasePage):
     name = 'sweetshop home page'
+    title = 'Sweet Shop'
+    url_path = '/'
     identity_checks = ['check_url']
     load_checks = [
         (True, By.XPATH, "//h1[contains(text(), 'Welcome to the sweet shop!')]"),
@@ -23,59 +25,11 @@ class HomePage(BasePage):
         (False, By.XPATH, "//h1[contains(text(), 'Welcome to the sweet shop!')]"),
     ]
 
-    def __init__(self, driver, firstload=False):
-        """
-            Because this is a start page for the application, it needs
-            some special handling:
-            1. an __init__ arg `firstload` that has to be set as True
-               from the test code for the first invocation of the POM.
-            2. clearing out the unload_checks if firstload=True
-
-            This special handling works around the fact that the start
-            page gets double-loaded, and so the first load can't perform
-            unload checks!
-
-            :param driver: webdriver instance
-            :param firstload: bool, True if this is a start page first load
-        """
-        self.url = 'https://' + self.domain
-        # increase the browser width in order to display the top nav links
+    def __init__(self, driver):
+        self.url = f"https://{self.domain}{self.url_path}"
         driver.set_window_size(1405, 2000)
         self.driver = driver
-        self.title = 'Sweet Shop'
-        if firstload:
-            self.unload_checks = None
-            msg = "Because this is the first load, do NOT check for unload!"
-            logger.warning(msg)
-        else:
-            # because the title is set in __init__(),
-            # the check also has to be set and added here
-            # note that title is used for the identity check, so we
-            # probably don't need it for a load check
-            titlecheck = (False, By.XPATH, f"//title[text()='{self.title}']")
-            self.unload_checks.append(titlecheck)
-        logger.info(f"\n-----> unload checks: {self.unload_checks}")
         logger.info('\n' + INIT_MSG % self.name)
-
-    def load(self):
-        """
-            Get and load the home page in the browser, then instantiate and
-            return a page object for the home page.
-
-            In the log record, you will see this page object instantiated
-            twice, because the test case called HomePage, and then
-            load() called HomePage again to change the browser to the
-            appropriate URL.
-
-            :return page: page object for the home page
-        """
-        self.driver.get(self.url)
-        logger.info(f"\nLoaded {self.appname} home page to url '{self.url}'.")
-
-        # instantiate and return a refreshed PO
-        po_selector = self.name
-        page = self.load_pageobject(po_selector)
-        return page
 
 
 class SweetsPage(BasePage):

--- a/welkin/framework/utils_selenium.py
+++ b/welkin/framework/utils_selenium.py
@@ -5,12 +5,57 @@ import pytest
 
 from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.common.by import By
+from selenium.webdriver.support.ui import WebDriverWait
 from selenium.common.exceptions import WebDriverException
 
 from welkin.framework import utils_webstorage
 from welkin.framework.exceptions import ControlInteractionException
 
 logger = logging.getLogger(__name__)
+
+
+def get_time_to_loadevent(driver, secs=True):
+    """
+        Get the performance timing for page load from the browser
+        and log it.
+
+        :param driver: webdriver instance
+        :param secs: bool, default True, to return time in seconds,
+                           else False for msecs
+        :return: float, time in seconds or msecs
+    """
+    msecs_start = driver.execute_script("return window.performance.timing.navigationStart")
+    msecs_loadevent = driver.execute_script("return window.performance.timing.loadEventEnd")
+
+    logger.info(f"\nstamp_start as msecs: {msecs_start}"
+                f"\nstamp_loadevent as msecs: {msecs_loadevent}")
+    if secs:
+        return (msecs_loadevent - msecs_start) / 1000
+    else:
+        return msecs_loadevent - msecs_start
+
+
+def get_readystate(driver, state='complete'):
+    """
+        Wait for the page to load by checking the document.readyState
+        property of the current page.
+
+        The possible states are:
+            + 'complete' (the default value)
+            + 'loading'
+            + 'interactive' (doc has loaded and DOM is ready, but sub-resources
+                             like images, stylesheets, and frames are still loading)
+            + 'uninitialized' (the document is still loading)
+
+        :param driver: webdriver instance
+        :param state: str enum, default 'complete', the state to check for
+        :return: Bool, True if the state is as expected, else False
+    """
+    logger.info(f"\n getting readyState for {state}")
+    # return driver.execute_script("return document.readyState") == state
+    return WebDriverWait(driver, 10).until(
+        lambda driver: driver.execute_script("return document.readyState") == state
+    )
 
 
 def take_and_save_screenshot(driver, filename=''):


### PR DESCRIPTION
apps/README_pageobject_model.md
+ minor documentation updates

apps/root_pageobject.py
+ renamed verify_load() to verify_load_by_elements()
+ updated load_pageobject() to call verify_load_by_elements()
+ updated load_pageobject() to call utils_selenium.get_readystate() to check for browser loadEvent completed; commented out the old check elements for load state

apps/sweetshop/noauth/pages.py
+ updated HomePage top use the POM loader

framework/utils_selenium.py
+ added get_time_to_loadevent()
+ added get_readystate()

tests/pytest.ini
+ added --durations to CLI