### PR TITLE
issue 153: accessibility logic refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -198,6 +198,7 @@ Temporary Items
 .idea/vcs.xml
 .idea/welkin.iml
 .idea/inspectionProfiles/
+/.idea/csv-editor.xml
 
 # Welkin artifacts
 output/

--- a/welkin/apps/root_pageobject.py
+++ b/welkin/apps/root_pageobject.py
@@ -2,7 +2,6 @@ import logging
 import importlib
 import time
 import pytest
-from axe_selenium_python import Axe
 
 from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.common.by import By
@@ -21,7 +20,7 @@ from welkin.framework.exceptions import ControlInteractionException
 
 from welkin.framework import checks
 from welkin.framework import utils, utils_file
-from welkin.framework import utils_selenium
+from welkin.framework import utils_selenium, utils_accessibility
 
 logger = logging.getLogger(__name__)
 
@@ -576,13 +575,9 @@ class RootPageObject(object):
                                              pageobject_name=self.name,
                                              event=event)
 
-    def generate_accessibility_review(self, filename=''):
+    def generate_accessibility_review(self, filename=None):
         """
-            Perform and save accessibility checks based on the axe engine.
-
-            The checks are run automatically for web pages handled
-            by a welkin page object model. Results are written to the
-            current test runs output/accessibility folder.
+            Wrapper for the accessibility review functionality.
 
             NOTE: these checks may slow down the perceived page performance
             around page load in the context of test runs.
@@ -597,33 +592,7 @@ class RootPageObject(object):
                              defaults to PO name
             :return: None
         """
-        # instantiate axe
-        axe = Axe(self.driver)
-
-        # inject axe.core into page
-        axe.inject()
-
-        event = f"Axe.core JS injected into page code for '{self.name}'"
-        self.set_event(event)
-
-        # run the axe accessibility checks
-        axe_results = axe.run()
-        # axe.run() caused the page to scroll to the bottom; scroll back to top
-        utils_selenium.scroll_to_top_of_page(self.driver)
-        event = f"Forced page scroll to top of page '{self.name}'"
-        self.set_event(event)
-
-        # we don't want the full report, just the violations & some metadata,
-        # so remove the unwanted stuff from the results
-        unwanted_sections = ['passes', 'incomplete', 'inapplicable']
-        for section in unwanted_sections:
-            axe_results.pop(section)
-
-        # set the cleaned file name
-        fname = filename if filename else self.name
-
-        # write the results to a file
-        utils_file.write_axe_log_to_file(axe_results, fname)
+        utils_accessibility.generate_axe_review(pageobject=self, filename=filename)
 
     def set_event(self, event_name, page_name=None):
         """

--- a/welkin/framework/utils_accessibility.py
+++ b/welkin/framework/utils_accessibility.py
@@ -1,0 +1,60 @@
+import logging
+from axe_selenium_python import Axe
+
+from welkin.framework import utils_file, utils_selenium
+
+logger = logging.getLogger(__name__)
+
+
+def generate_axe_review(pageobject, filename=None):
+    """
+        Perform and save accessibility checks based on the axe engine.
+
+        The checks are run automatically for web pages handled
+        by a welkin page object model. Results are written to the
+        current test runs output/accessibility folder.
+
+        NOTE: these checks may slow down the perceived page performance
+        around page load in the context of test runs.
+
+        The filename can be specified by the calling code, but the
+        expectation is that this is either:
+            1. an event string, because the trigger for running these
+               checks could be a page object load or reload
+            2. the default of the page object's name
+
+        :param pageobject: pageobject instance for current page
+        :param filename: str filename for the log file;
+                         defaults to PO name
+        :return: None
+    """
+    # instantiate axe
+    axe = Axe(pageobject.driver)
+
+    # inject axe.core into page
+    axe.inject()
+
+    event = f"Axe.core JS injected into page code for '{pageobject.name}'"
+    pageobject.set_event(event)
+
+    # run the axe accessibility checks
+    axe_results = axe.run()
+    # axe.run() caused the page to scroll to the bottom; scroll back to top
+    utils_selenium.scroll_to_top_of_page(pageobject.driver)
+    event = f"Forced page scroll to top of page '{pageobject.name}'"
+    pageobject.set_event(event)
+
+    # we don't want the full report, just the violations & some metadata,
+    # so remove the unwanted stuff from the results
+    unwanted_sections = ['passes', 'incomplete', 'inapplicable']
+    for section in unwanted_sections:
+        axe_results.pop(section)
+
+    # set the cleaned file name
+    fname = filename if filename else pageobject.name
+
+    # write the results to a file
+    utils_file.write_axe_log_to_file(axe_results, fname)
+
+    # write as csv
+    utils_file.write_axe_failures_to_csv(axe_results, fname)


### PR DESCRIPTION
.gitignore
+ ignored csv-editor.xml

apps/root_pageobject.py
+ refactored generate_accessibility_review() to call Axe logic in utils_accesibility::generate_axe_review()

framework/utils_accessibility.py
+ added file, with generate_axe_review()
+ updated generate_axe_review() with a call on utils_file.write_axe_failures_to_csv()

framework/utils_file.py
+ added write_axe_failures_to_csv(), which includes process_json() & json_to_csv()