### PR TITLE
support Merriam-Webster API

### DIFF
--- a/welkin/apps/merriam_webster/base_endpoint.py
+++ b/welkin/apps/merriam_webster/base_endpoint.py
@@ -1,0 +1,18 @@
+import logging
+
+from welkin.apps.root_endpoint import RootEndpoint
+
+
+logger = logging.getLogger(__name__)
+
+
+class BaseEndpoint(RootEndpoint):
+    """
+        Common ancestor for all endpoints.
+    """
+    base_url = 'https://dictionaryapi.com/api/v3/references/collegiate/json/'
+
+    # the header to be used for all requests
+    headers = {
+        'Content-Type': 'application/json',
+    }

--- a/welkin/apps/merriam_webster/collegiate_dictionary.py
+++ b/welkin/apps/merriam_webster/collegiate_dictionary.py
@@ -1,0 +1,44 @@
+import logging
+
+from welkin.apps.merriam_webster import base_endpoint
+from welkin.framework.utils import plog
+
+
+logger = logging.getLogger(__name__)
+
+
+class CollegiateDictionaryEndpoint(base_endpoint.BaseEndpoint):
+
+    def __init__(self, key):
+        """
+            The Collegiate Dictionary has just one endpoint, which takes two
+            parameters:
+                1. the word to look up
+                2. the API key
+
+            Instantiate the endpoint with the API key.THis has to be passed
+            in the URL, and not through the headers.
+
+            See reference: https://dictionaryapi.com/products/json
+
+            :param key: str, API key
+            :return: None
+        """
+        self.name = 'dictionary'
+        self.api_key = key
+        self.url_key_phrase = f"?key={self.api_key}"
+
+        logger.info(f"{self.name} endpoint object created.")
+
+    def get_word(self, word):
+        """
+            Grab the information for one word as specified by the
+            word itself.
+
+            :param word: str, word to look up
+            :return res: Requests response object
+        """
+        url = self.base_url + word + self.url_key_phrase
+        res = self.get(url, headers=self.headers)
+        logger.info(f"res: {res.text}")
+        return res

--- a/welkin/framework/utils.py
+++ b/welkin/framework/utils.py
@@ -106,3 +106,20 @@ def plog(content):
                 pass
 
     return formatted_content
+
+
+def get_env_variable(var_name):
+    """
+        Get the value of an environment variable.
+
+        :param var_name: str, the name of the environment variable
+        :return: str, the value of the environment variable
+    """
+    import os
+    value = os.getenv(var_name)
+    if value:
+        return value
+    else:
+        msg = f"Environment variable {var_name} not found."
+        logger.error(msg)
+        raise ValueError(msg)

--- a/welkin/tests/conftest.py
+++ b/welkin/tests/conftest.py
@@ -635,7 +635,8 @@ def set_up_testcase_reporting(testcase_folder, fixturenames):
         integrations = ['auth']  # not used, but helps with context  # noqa: F841
         drivers = ['driver']
         web_apps = ['duckduckgo', 'sweetshop']
-        apis = ['colourlovers', 'dadjokes', 'genderizer', 'data_dot_gov']
+        apis = ['colourlovers', 'dadjokes', 'genderizer',
+                'data_dot_gov', 'merriam_webster']
 
         # set up config for folder requirements
         required_folders = {
@@ -1378,11 +1379,31 @@ def sweetshop(request):
 
 
 @pytest.fixture(scope='session')
+def merriam_webster(request):
+    """
+        This test fixture is a trigger for setting up authentication
+        management for the Merriam-Webster api.
+
+        Pull in the app's api-key from the local ENV (via .bash_profile).
+
+        :param request: pytest request object
+        :return api_key: str, api key for Merriam-Webster
+    """
+    api_key = utils.get_env_variable('MERRIAM_WEBSTER_API_KEY')
+    return api_key
+
+
+@pytest.fixture(scope='session')
 def data_dot_gov(request):
     """
         This test fixture is a trigger for setting up authentication
         management for the data.gov api.
 
+        Pull in the api-key from the CLI; that has to be part for
+        every invocation.
+
+        :param request: pytest request object
+        :return api_key: str, api key for data.gov
     """
     api_key = request.config.option.data_dot_gov
     logger.info('\ndata.gov api_key: %s' % api_key)

--- a/welkin/tests/merriam_webster/test_dictionary.py
+++ b/welkin/tests/merriam_webster/test_dictionary.py
@@ -1,0 +1,54 @@
+import pytest
+import logging
+import time
+
+from welkin.framework import utils
+from welkin.apps.merriam_webster import collegiate_dictionary as mw
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.mark.example
+@pytest.mark.api
+class CollegiateDictionaryTests(object):
+
+    @pytest.mark.parametrize('words', [
+        'run',
+        'retreat',
+        'run-of-the-mill',
+        'fetching'
+    ])
+    def test_get_definition(self, merriam_webster, words):
+        """
+            Simple test for the word endpoint.
+
+            Note that our tests are only for simple words that are not stemmed
+            so much that they are unrecognizable. We are not testing for
+            edge cases or for words that are not in the dictionary.
+
+            :param merriam_webster: str, the API key
+            :param words: str, the word to look up
+            :return: None
+        """
+        # disambiguation
+        api_key = merriam_webster
+        word = words
+
+        # instantiate the API instance with the API key
+        api = mw.CollegiateDictionaryEndpoint(api_key)
+
+        # get a definition
+        res = api.get_word(word)
+
+        # test point: verify the correct response for a correct api call
+        assert res.status_code == 200
+
+        # get the json payload so we can make some checks
+        payload = res.json()
+        logger.info(utils.plog(payload))
+
+        # the searched-for word should be in the response
+        id = payload[0]['meta']['id']  # just the first one
+        check_point = id[:id.find(':')] if id.find(':') > 0 else id
+        assert check_point == word
+


### PR DESCRIPTION
apps/merriam_webster/__init__.oy
+ added wrapper folder

apps/merriam_webster/base_endpoint.py
+ added BaseEndpoint()

apps/merriam_webster/collegiate_dictionary.py
+ added CollegiateDictionaryEndpoint

framework/utils.py
+ added get_env_variable()

tests/conftest.py
+ added merriam_webster()
+ added "merriam_webster" to apis list in set_up_testcase_reporting()

tests/merriam_webster/test_dictionary.py
+ added test_get_definition()